### PR TITLE
Fix recommended typo in compose config

### DIFF
--- a/common-compose-config.yaml
+++ b/common-compose-config.yaml
@@ -18,7 +18,7 @@ services:
       - NUM_SHARDS=128 # Higher number of shards increases memory overhead but usually leads to better RPS. Extremely high number of shards may lead to key collisions. Hard limit is 4,294,967,295
       - CONN_QUEUE_LIMIT=1048576 # Align with net.core.netdev_max_backlog = 1048576, net.core.somaxconn = 1048576 settings of kernel
       - SOCK_BUF_SIZE=4194304 # Request 4 mb socket buffer, depends on system tcp_rmem and tcp_wmem settings
-      - ENABLE_COMPRESSION=true # Compression is reccomended to be enabled. Small values are not compressed by default. TODO: introduce compression threshold setting (now all values of > 30 bytes are compressed)
+      - ENABLE_COMPRESSION=true # Compression is recommended to be enabled. Small values are not compressed by default. TODO: introduce compression threshold setting (now all values of > 30 bytes are compressed)
     ports:
       - "9001:9001"
       - "8080:8080"


### PR DESCRIPTION
## Summary
- fix typo in compose configuration comment

## Testing
- `bash ./run-all-tests.bash` *(fails: gtest/gtest.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_684effa4b2c483338861a3592bbda281