### PR TITLE
Fix delete failure return

### DIFF
--- a/src/kvs/kvs.cpp
+++ b/src/kvs/kvs.cpp
@@ -269,5 +269,5 @@ bool kvs::KeyValueStore::del(const char *key, uint_fast64_t hash)
 #ifndef NDEBUG
     std::cerr << "Failed to find key during deletion, key = " << key << " after " << attempt << " attempts." << std::endl;
 #endif
-    return true;
+    return false;
 }


### PR DESCRIPTION
## Summary
- report failure when key is missing in `KeyValueStore::del`

## Testing
- `bash ./run-all-tests.bash` *(fails: gtest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684effb4a9688333a2a017cddf348cbb