### PR TITLE
Add test for deleting a nonexistent key

### DIFF
--- a/src/kvs/kvs_test.cpp
+++ b/src/kvs/kvs_test.cpp
@@ -155,6 +155,11 @@ TEST(KeyValueStoreTest, DeleteElements) {
 
 }
 
+TEST(KeyValueStoreTest, DeleteNonexistentKey) {
+    KeyValueStore kvStore;
+    ASSERT_FALSE(kvStore.del("missing"));
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
## Summary
- add `DeleteNonexistentKey` unit test to verify `del` fails on missing keys

## Testing
- `bash run-all-tests.bash` *(fails: gtest headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_684effc9800083338e9e8ee5ccc5e8e4