### PR TITLE
Add request pipelining support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ test_gzip
 .venv
 out
 callgrind.out.*
+__pycache__
+prometheus-cpp

--- a/src/primegen/primegen.h
+++ b/src/primegen/primegen.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <iostream>
+#include <cstdint>
 #include <vector>
 #include <queue>
 #include <bitset>

--- a/src/server/conn_manager.hpp
+++ b/src/server/conn_manager.hpp
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <coroutine>
 #include <unordered_map>
+#include <string>
 #include <sys/socket.h>
 #include <sys/epoll.h>
 #include <netinet/in.h>
@@ -17,6 +18,10 @@ namespace server {
     struct ConnectionData {
         timespec lastActivity {0, 0};
         int epoll_fd = -1;
+        std::string readBuffer;
+
+        ConnectionData() = default;
+        ConnectionData(timespec ts, int epfd) : lastActivity(ts), epoll_fd(epfd) {}
     };
 
     class ConnManager {


### PR DESCRIPTION
## Summary
- support request pipelining with a per-connection buffer
- parse buffered requests when handling epoll events
- add python test for pipelining
- minor build fix for primegen and update gitignore

## Testing
- `bash run-all-tests.bash`

------
https://chatgpt.com/codex/tasks/task_e_6855abf512688333906fa4f88dcaf4fe