### PR TITLE
Add pipelining support in python tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ test_gzip
 .venv
 out
 callgrind.out.*
+prometheus-cpp/
+tests/__pycache__/

--- a/tests/connection_pool.py
+++ b/tests/connection_pool.py
@@ -1,0 +1,35 @@
+import asyncio
+
+class ConnectionPool:
+    def __init__(self, host: str, port: int, size: int):
+        self.host = host
+        self.port = port
+        self.size = size
+        self.connections = asyncio.Queue()
+        self.initialized = False
+
+    async def initialize(self):
+        for _ in range(self.size):
+            reader, writer = await asyncio.open_connection(self.host, self.port)
+            await self.connections.put((reader, writer))
+        self.initialized = True
+
+    async def acquire(self):
+        return await self.connections.get()
+
+    async def release(self, conn):
+        await self.connections.put(conn)
+
+    async def close(self):
+        while not self.connections.empty():
+            reader, writer = await self.connections.get()
+            writer.close()
+            await writer.wait_closed()
+
+    async def discard(self, conn):
+        reader, writer = conn
+        try:
+            writer.close()
+            await writer.wait_closed()
+        except Exception:
+            pass

--- a/tests/tcp_server_test.py
+++ b/tests/tcp_server_test.py
@@ -4,6 +4,7 @@ import time
 import logging
 import asyncio
 import multiprocessing
+import argparse
 
 # Logger config
 logger = logging.getLogger(__name__)
@@ -24,37 +25,15 @@ data_folder = os.environ.get('TEST_DATA_FOLDER', './data')
 MSG_SEPARATOR = '\x1F'
 ENCODED_SEPARATOR = MSG_SEPARATOR.encode()
 
-class ConnectionPool:
-    def __init__(self, size):
-        self.size = size
-        self.connections = asyncio.Queue()
-        self.initialized = False
+parser = argparse.ArgumentParser(description="Cache server functional tests")
+parser.add_argument('-p', '--pipeline', action='store_true', help='Use pipelining for requests')
+parser.add_argument('-b', '--batch_size', type=int, default=max(1, iterations_count // 10),
+                    help='Batch size for pipelined requests')
+args, _ = parser.parse_known_args()
+pipelining_enabled = args.pipeline
+batch_size = args.batch_size
 
-    async def initialize(self):
-        for _ in range(self.size):
-            reader, writer = await asyncio.open_connection(host, port)
-            await self.connections.put((reader, writer))
-        self.initialized = True
-
-    async def acquire(self):
-        return await self.connections.get()
-
-    async def release(self, conn):
-        await self.connections.put(conn)
-
-    async def close(self):
-        while not self.connections.empty():
-            reader, writer = await self.connections.get()
-            writer.close()
-            await writer.wait_closed()
-
-    async def discard(self, conn):
-        reader, writer = conn
-        try:
-            writer.close()
-            await writer.wait_closed()
-        except:
-            pass
+from connection_pool import ConnectionPool
 
 async def send_command(command: str, conn_pool: ConnectionPool, buf_size=1024):
     reader, writer = await conn_pool.acquire()
@@ -130,7 +109,7 @@ async def preload_json_files(conn_pool):
         logger.info(f"Stored {key}")
         await asyncio.sleep(delay_sec)
 
-async def worker_main_single_connection(start_idx, end_idx, task_type):
+async def worker_main_single_connection(start_idx, end_idx, task_type, pipeline=False, batch_size=1):
     reader, writer = await asyncio.open_connection(host, port)
 
     async def send_command(command: str):
@@ -171,40 +150,84 @@ async def worker_main_single_connection(start_idx, end_idx, task_type):
         return False
 
     results = []
-    for i in range(start_idx, end_idx):
-        if task_type == "set":
-            result = await send_with_retry(f"SET key{i} value{i}", "OK")
-        elif task_type == "get":
-            result = await send_with_retry(f"GET key{i}", f"value{i}")
-        elif task_type == "del":
-            result = await send_with_retry(f"DEL key{i}", "OK")
-        elif task_type == "workflow":
-            result = (await send_with_retry(f"SET key{i} value{i}", "OK") and
-                      await send_with_retry(f"GET key{i}", f"value{i}") and
-                      await send_with_retry("GET non_existent_key", "(nil)"))
-        else:
-            raise ValueError("Unknown task_type")
-        results.append(result)
+
+    if not pipeline:
+        for i in range(start_idx, end_idx):
+            if task_type == "set":
+                result = await send_with_retry(f"SET key{i} value{i}", "OK")
+            elif task_type == "get":
+                result = await send_with_retry(f"GET key{i}", f"value{i}")
+            elif task_type == "del":
+                result = await send_with_retry(f"DEL key{i}", "OK")
+            elif task_type == "workflow":
+                result = (
+                    await send_with_retry(f"SET key{i} value{i}", "OK")
+                    and await send_with_retry(f"GET key{i}", f"value{i}")
+                    and await send_with_retry("GET non_existent_key", "(nil)")
+                )
+            else:
+                raise ValueError("Unknown task_type")
+            results.append(result)
+    else:
+        i = start_idx
+        while i < end_idx:
+            batch_end = min(i + batch_size, end_idx)
+            commands = []
+            expected = []
+            for j in range(i, batch_end):
+                if task_type == "set":
+                    commands.append(f"SET key{j} value{j}")
+                    expected.append("OK")
+                elif task_type == "get":
+                    commands.append(f"GET key{j}")
+                    expected.append(f"value{j}")
+                elif task_type == "del":
+                    commands.append(f"DEL key{j}")
+                    expected.append("OK")
+                elif task_type == "workflow":
+                    commands.extend([
+                        f"SET key{j} value{j}",
+                        f"GET key{j}",
+                        "GET non_existent_key",
+                    ])
+                    expected.extend(["OK", f"value{j}", "(nil)"])
+                else:
+                    raise ValueError("Unknown task_type")
+
+            writer.write(MSG_SEPARATOR.join(commands).encode() + ENCODED_SEPARATOR)
+            await writer.drain()
+            for exp in expected:
+                resp = await reader.readuntil(ENCODED_SEPARATOR)
+                results.append(resp.decode().rstrip(MSG_SEPARATOR) == exp)
+            i = batch_end
 
     writer.close()
     await writer.wait_closed()
     return len(results) - sum(results)  # number of failures
 
-def run_worker(start_idx, end_idx, task_type):
-    return asyncio.run(worker_main_single_connection(start_idx, end_idx, task_type))
+def run_worker(start_idx, end_idx, task_type, pipeline=False, batch_size=1):
+    return asyncio.run(
+        worker_main_single_connection(start_idx, end_idx, task_type, pipeline, batch_size)
+    )
 
 async def run_preload():
-    pool = ConnectionPool(pool_size)
+    pool = ConnectionPool(host, port, pool_size)
     await pool.initialize()
     try:
         await preload_json_files(pool)
     finally:
         await pool.close()
 
-def run_parallel(task_type, test_name, requests_multiplier=1):
+def run_parallel(task_type, test_name, requests_multiplier=1, pipeline=False, batch_size=1):
     chunk_size = iterations_count // num_processes
     args_list = [
-        (i * chunk_size, (i + 1) * chunk_size if i != num_processes - 1 else iterations_count, task_type)
+        (
+            i * chunk_size,
+            (i + 1) * chunk_size if i != num_processes - 1 else iterations_count,
+            task_type,
+            pipeline,
+            batch_size,
+        )
         for i in range(num_processes)
     ]
     logger.info(f"Running {test_name} with {iterations_count} iterations {num_processes} processes and {chunk_size} chunks per process ...")
@@ -220,33 +243,40 @@ def run_parallel(task_type, test_name, requests_multiplier=1):
     print(f"{test_name} completed in {duration:.2f}s — RPS: {rps:.2f}, Failures: {failures}, Processes: {num_processes}")
     return 1 if failures else 0
 
-def run_set_tests(): return run_parallel("set", "SET tests")
-def run_get_tests(): return run_parallel("get", "GET tests")
-def run_del_tests(): return run_parallel("del", "DEL tests")
-def run_workflow_tests(): return run_parallel("workflow", "Workflow tests", requests_multiplier=3)
+def run_set_tests():
+    return run_parallel("set", "SET tests", pipeline=pipelining_enabled, batch_size=batch_size)
+
+def run_get_tests():
+    return run_parallel("get", "GET tests", pipeline=pipelining_enabled, batch_size=batch_size)
+
+def run_del_tests():
+    return run_parallel("del", "DEL tests", pipeline=pipelining_enabled, batch_size=batch_size)
+
+def run_workflow_tests():
+    return run_parallel(
+        "workflow",
+        "Workflow tests",
+        requests_multiplier=3,
+        pipeline=pipelining_enabled,
+        batch_size=batch_size,
+    )
 
 async def pipeline_scenario():
-    reader, writer = await asyncio.open_connection(host, port)
-    writer.write(b"SET a 1\x1FSET b 2\x1FGET a\x1FDEL b\x1FGET b\x1FDEL a\x1F")
-    await writer.drain()
-
-    responses = []
-    for _ in range(6):
-        resp = await reader.readuntil(ENCODED_SEPARATOR)
-        responses.append(resp.decode().rstrip(MSG_SEPARATOR))
-
-    writer.close()
-    await writer.wait_closed()
-    return responses
+    failures = 0
+    failures += await worker_main_single_connection(0, iterations_count, "set", True, batch_size)
+    failures += await worker_main_single_connection(0, iterations_count, "get", True, batch_size)
+    failures += await worker_main_single_connection(0, iterations_count, "del", True, batch_size)
+    failures += await worker_main_single_connection(0, iterations_count, "workflow", True, batch_size)
+    return failures
 
 def run_pipeline_test():
     logger.info("Running pipeline test ...")
-    responses = asyncio.run(pipeline_scenario())
-    if responses == ["OK", "OK", "1", "OK", "(nil)", "OK"]:
+    failures = asyncio.run(pipeline_scenario())
+    if failures == 0:
         print("Pipeline test passed")
         return 0
     else:
-        print(f"Pipeline test failed: {responses}")
+        print(f"Pipeline test failed: {failures} failures")
         return 1
 
 def main():


### PR DESCRIPTION
## Summary
- extract `ConnectionPool` into dedicated module
- allow test runner to pipeline requests via new `-p/--pipeline` flag
- support configurable batch size with `-b/--batch_size`
- update pipeline scenario to reuse main worker logic
- ignore build artefacts

## Testing
- `python -m py_compile tests/tcp_server_test.py tests/connection_pool.py`

------
https://chatgpt.com/codex/tasks/task_e_68583a3c91b083339b7445ab9433435d