### PR TITLE
Configure CodeQL build for C++ project

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,72 @@
+name: CodeQL
+
+on:
+  push:
+    branches: ["main", "dev*", "release/*", "codex/*"]
+  pull_request:
+    branches: ["main", "dev*", "release/*", "codex/*"]
+  schedule:
+    - cron: '0 3 * * 1'
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["cpp"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y software-properties-common
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+          sudo apt-get install -y gcc-14 g++-14 cmake ninja-build pkg-config zlib1g-dev libgtest-dev
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 140
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 140
+
+      - name: Build prometheus-cpp dependency
+        env:
+          CC: gcc-14
+          CXX: g++-14
+        run: |
+          cmake -S prometheus-cpp -B prometheus-cpp/_build -G Ninja \
+            -DBUILD_SHARED_LIBS=ON \
+            -DENABLE_TESTING=OFF \
+            -DENABLE_PUSH=OFF \
+            -DENABLE_COMPRESSION=OFF \
+            -DENABLE_LOGGING=OFF
+          cmake --build prometheus-cpp/_build --parallel
+          cmake --install prometheus-cpp/_build --prefix "${{ github.workspace }}/prometheus-cpp/_install"
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Configure project
+        env:
+          CC: gcc-14
+          CXX: g++-14
+          CMAKE_PREFIX_PATH: "${{ github.workspace }}/prometheus-cpp/_install"
+        run: |
+          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build project
+        run: cmake --build build --config Release --parallel
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}

--- a/README.md
+++ b/README.md
@@ -198,6 +198,32 @@ Run unit tests:
 ```
 ./run-all-tests.bash
 ```
+
+### Static analysis (CodeQL)
+
+The repository is scanned with GitHub CodeQL. The workflow builds the project with GCC 14 and a locally installed copy of `prometheus-cpp`. To reproduce the same environment locally, use the following commands (they require sudo privileges):
+
+```bash
+sudo apt-get update
+sudo apt-get install -y software-properties-common
+sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+sudo apt-get update
+sudo apt-get install -y gcc-14 g++-14 cmake ninja-build pkg-config zlib1g-dev libgtest-dev
+
+cmake -S prometheus-cpp -B prometheus-cpp/_build -G Ninja \
+  -DBUILD_SHARED_LIBS=ON \
+  -DENABLE_TESTING=OFF \
+  -DENABLE_PUSH=OFF \
+  -DENABLE_COMPRESSION=OFF \
+  -DENABLE_LOGGING=OFF
+cmake --build prometheus-cpp/_build --parallel
+cmake --install prometheus-cpp/_build --prefix "$(pwd)/prometheus-cpp/_install"
+
+CMAKE_PREFIX_PATH="$(pwd)/prometheus-cpp/_install" cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+cmake --build build --config Release --parallel
+```
+
+Running the steps above ensures the CodeQL build matches the CI configuration and that the necessary dependencies are present before launching a local CodeQL analysis.
 > [!TIP]
 > Use Ctrl+C to send SIGTERM
 


### PR DESCRIPTION
## Summary
- add a dedicated CodeQL workflow that installs the required toolchain, builds prometheus-cpp, and compiles the cache server during analysis
- document the CodeQL build steps in the README so local runs match the CI environment

## Testing
- `cmake -S prometheus-cpp -B prometheus-cpp/_codeql_build -G Ninja -DBUILD_SHARED_LIBS=ON -DENABLE_TESTING=OFF -DENABLE_PUSH=OFF -DENABLE_COMPRESSION=OFF -DENABLE_LOGGING=OFF`
- `cmake --build prometheus-cpp/_codeql_build --parallel`
- `cmake --install prometheus-cpp/_codeql_build --prefix "$(pwd)/prometheus-cpp/_install"`
- `CMAKE_PREFIX_PATH="$(pwd)/prometheus-cpp/_install" cmake -S . -B build-codeql -G Ninja -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build-codeql --config Release --parallel`


------
https://chatgpt.com/codex/tasks/task_e_68e2b1d6d27c8333884dce1ff65f031a