### PR TITLE
Guard pipelined GETs from mutation races

### DIFF
--- a/docker-compose-local.yaml
+++ b/docker-compose-local.yaml
@@ -10,6 +10,7 @@ services:
       service: cache-common
     profiles:
       - main
+      - tests
     networks:
       - cache_network
 

--- a/docker-compose.yaml.j2
+++ b/docker-compose.yaml.j2
@@ -10,6 +10,9 @@ services:
       service: cache-common
     profiles:
       - main
+      - tests
+      - tests-pipelined
+      - tests-req-per-conn
     networks:
       - cache_network
 
@@ -26,6 +29,20 @@ services:
     networks:
       - cache_network
 {% endfor %}
+
+  client-integration:
+    build:
+      context: .
+      dockerfile: tests/client_integration/Dockerfile
+    environment:
+      - CACHE_HOST=cache
+      - CACHE_PORT=9001
+    depends_on:
+      - cache
+    profiles:
+      - tests
+    networks:
+      - cache_network
 
   tests-pipelined:
     extends:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,3 +24,7 @@ if(PROMETHEUS_CPP_ENABLE_PULL)
 endif()
 
 target_link_libraries(${PROJECT_NAME} PRIVATE ZLIB::ZLIB)
+
+add_library(pmc_cache_client INTERFACE)
+target_include_directories(pmc_cache_client INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+target_sources(pmc_cache_client INTERFACE FILE_SET HEADERS BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR} FILES client/cache_client.hpp)

--- a/src/client/cache_client.hpp
+++ b/src/client/cache_client.hpp
@@ -1,0 +1,522 @@
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cerrno>
+#include <deque>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <iterator>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+namespace pmc {
+
+/**
+ * @brief Header-only cache client for the poor-man-s-cache server.
+ *
+ * The client implements the textual protocol understood by the cache server
+ * and provides a small RAII friendly interface that supports request
+ * pipelining.  Requests are queued locally and flushed to the server on demand
+ * so multiple commands can be sent without waiting for their responses.
+ */
+class CacheClient {
+public:
+    /// Unique identifier associated with each request.
+    using RequestId = std::uint64_t;
+
+    /// Commands supported by the server.
+    enum class RequestType {
+        Get,
+        Set,
+        Delete,
+    };
+
+    /// Result classification returned by the client.
+    enum class ResultCode {
+        Ok,        ///< Command executed successfully.
+        NotFound,  ///< Returned when a key does not exist.
+        Error,     ///< Server reported an error.
+    };
+
+    /// Parsed response returned by the server.
+    struct Response {
+        RequestId requestId{};
+        RequestType requestType{};
+        ResultCode result{ResultCode::Error};
+        std::string value;        ///< Value for GET requests when result == Ok.
+        std::string errorMessage; ///< Filled when result == Error.
+
+        [[nodiscard]] bool ok() const noexcept { return result == ResultCode::Ok; }
+        [[nodiscard]] bool notFound() const noexcept { return result == ResultCode::NotFound; }
+        [[nodiscard]] bool hasError() const noexcept { return result == ResultCode::Error; }
+    };
+
+    struct Options {
+        std::string host{"127.0.0.1"};
+        std::uint16_t port{7000};
+        std::chrono::milliseconds sendTimeout{0};
+        std::chrono::milliseconds receiveTimeout{0};
+    };
+
+    CacheClient() = default;
+    explicit CacheClient(Options options) : options_(std::move(options)) {}
+    CacheClient(const CacheClient&) = delete;
+    CacheClient& operator=(const CacheClient&) = delete;
+
+    CacheClient(CacheClient&& other) noexcept { moveFrom(std::move(other)); }
+    CacheClient& operator=(CacheClient&& other) noexcept {
+        if (this != &other) {
+            close();
+            moveFrom(std::move(other));
+        }
+        return *this;
+    }
+
+    ~CacheClient() { close(); }
+
+    /// Establishes a TCP connection to the configured host.
+    void connect() {
+        if (connected()) {
+            return;
+        }
+
+        const auto portStr = std::to_string(options_.port);
+
+        addrinfo hints{};
+        hints.ai_family = AF_UNSPEC;
+        hints.ai_socktype = SOCK_STREAM;
+
+        addrinfo* result = nullptr;
+        const int gaiErr = ::getaddrinfo(options_.host.c_str(), portStr.c_str(), &hints, &result);
+        if (gaiErr != 0) {
+            throw std::system_error(gaiErr, std::generic_category(), "Failed to resolve cache server host");
+        }
+
+        int fd = -1;
+        int lastErrno = 0;
+        for (addrinfo* rp = result; rp != nullptr; rp = rp->ai_next) {
+            int socketType = rp->ai_socktype;
+#ifdef SOCK_CLOEXEC
+            socketType |= SOCK_CLOEXEC;
+#endif
+            fd = ::socket(rp->ai_family, socketType, rp->ai_protocol);
+            if (fd == -1) {
+                lastErrno = errno;
+                continue;
+            }
+
+#ifdef SO_NOSIGPIPE
+            int enable = 1;
+            ::setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &enable, sizeof(enable));
+#endif
+
+            int flag = 1;
+            ::setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag));
+
+            if (options_.sendTimeout.count() > 0) {
+                const auto tv = toTimeVal(options_.sendTimeout);
+                ::setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+            }
+
+            if (options_.receiveTimeout.count() > 0) {
+                const auto tv = toTimeVal(options_.receiveTimeout);
+                ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+            }
+
+            if (::connect(fd, rp->ai_addr, rp->ai_addrlen) == 0) {
+                socketFd_ = fd;
+                break;
+            }
+
+            lastErrno = errno;
+            ::close(fd);
+            fd = -1;
+        }
+
+        ::freeaddrinfo(result);
+
+        if (fd == -1 || !connected()) {
+            throw std::system_error(lastErrno == 0 ? errno : lastErrno, std::system_category(),
+                                    "Failed to connect to cache server");
+        }
+    }
+
+    /// Closes the socket connection.
+    void close() noexcept {
+        if (socketFd_ != -1) {
+            ::close(socketFd_);
+            socketFd_ = -1;
+        }
+        queuedRequests_.clear();
+        inflightRequests_.clear();
+        queuedCommandCount_ = 0;
+        completedResponses_.clear();
+        sendBuffer_.clear();
+        sendOffset_ = 0;
+        receiveBuffer_.clear();
+        nextRequestId_ = 1;
+    }
+
+    [[nodiscard]] bool connected() const noexcept { return socketFd_ != -1; }
+
+    RequestId enqueueGet(std::string_view key) {
+        return enqueue(RequestType::Get, key, {});
+    }
+
+    RequestId enqueueSet(std::string_view key, std::string_view value) {
+        ensureNoConflictingReads(key);
+        return enqueue(RequestType::Set, key, value);
+    }
+
+    RequestId enqueueDelete(std::string_view key) {
+        ensureNoConflictingReads(key);
+        return enqueue(RequestType::Delete, key, {});
+    }
+
+    /// Flushes all pending requests to the server.
+    void flush() { flushQueued(true); }
+
+    /// Receives the next response from the server.
+    Response receiveResponse() {
+        ensureConnected();
+
+        if (inflightRequests_.empty()) {
+            throw std::logic_error("No pending requests to receive responses for");
+        }
+
+        while (true) {
+            if (auto response = tryParseResponse()) {
+                return *response;
+            }
+
+            char buffer[4096];
+            const auto received = ::recv(socketFd_, buffer, sizeof(buffer), 0);
+            if (received == -1) {
+                if (errno == EINTR) {
+                    continue;
+                }
+                throw std::system_error(errno, std::system_category(), "Failed to receive data from cache server");
+            }
+
+            if (received == 0) {
+                throw std::runtime_error("Connection closed by cache server");
+            }
+
+            receiveBuffer_.insert(receiveBuffer_.end(), buffer, buffer + received);
+        }
+    }
+
+    /// Waits for the response that corresponds to the provided request id.
+    Response waitFor(RequestId id) {
+        if (auto cached = popCompleted(id)) {
+            return std::move(*cached);
+        }
+
+        ensureFlushedFor(id);
+
+        while (true) {
+            Response response = receiveResponse();
+            if (response.requestId == id) {
+                return response;
+            }
+            completedResponses_.emplace(response.requestId, std::move(response));
+        }
+    }
+
+    Response get(std::string_view key) {
+        const auto id = enqueueGet(key);
+        flush();
+        return waitFor(id);
+    }
+
+    Response set(std::string_view key, std::string_view value) {
+        const auto id = enqueueSet(key, value);
+        flush();
+        return waitFor(id);
+    }
+
+    Response del(std::string_view key) {
+        const auto id = enqueueDelete(key);
+        flush();
+        return waitFor(id);
+    }
+
+    [[nodiscard]] std::size_t pendingRequestCount() const noexcept {
+        return queuedCommandCount_;
+    }
+
+private:
+    struct PendingRequest {
+        RequestId id;
+        RequestType type;
+        std::string key;
+    };
+
+    static constexpr char MSG_SEPARATOR = 0x1F;
+    static constexpr std::string_view NOTHING = "(nil)";
+    static constexpr std::string_view KEY_NOT_EXISTS = "ERROR: Key does not exist";
+
+    Options options_{};
+    int socketFd_{-1};
+    std::deque<PendingRequest> queuedRequests_{};
+    std::deque<PendingRequest> inflightRequests_{};
+    std::size_t queuedCommandCount_{0};
+    std::unordered_map<RequestId, Response> completedResponses_{};
+    std::string sendBuffer_{};
+    std::size_t sendOffset_{0};
+    std::vector<char> receiveBuffer_{};
+    RequestId nextRequestId_{1};
+
+    void ensureConnected() {
+        if (!connected()) {
+            connect();
+        }
+    }
+
+    static timeval toTimeVal(std::chrono::milliseconds duration) {
+        timeval tv{};
+        tv.tv_sec = static_cast<long>(duration.count() / 1000);
+        tv.tv_usec = static_cast<long>((duration.count() % 1000) * 1000);
+        return tv;
+    }
+
+    static int sendFlags() {
+#ifdef MSG_NOSIGNAL
+        return MSG_NOSIGNAL;
+#else
+        return 0;
+#endif
+    }
+
+    RequestId enqueue(RequestType type, std::string_view key, std::optional<std::string_view> value) {
+        ensureConnected();
+        validateKey(key);
+        if (value && value->find(MSG_SEPARATOR) != std::string_view::npos) {
+            throw std::invalid_argument("Value contains protocol separator character");
+        }
+
+        const RequestId id = nextRequestId_++;
+        queuedRequests_.push_back(PendingRequest{id, type, std::string(key)});
+        ++queuedCommandCount_;
+
+        appendCommand(type, key, value);
+        return id;
+    }
+
+    void appendCommand(RequestType type, std::string_view key, std::optional<std::string_view> value) {
+        switch (type) {
+            case RequestType::Get:
+                sendBuffer_.append("GET ");
+                break;
+            case RequestType::Set:
+                sendBuffer_.append("SET ");
+                break;
+            case RequestType::Delete:
+                sendBuffer_.append("DEL ");
+                break;
+        }
+
+        sendBuffer_.append(key);
+        if (value.has_value()) {
+            sendBuffer_.push_back(' ');
+            sendBuffer_.append(value->data(), value->size());
+        }
+        sendBuffer_.push_back(MSG_SEPARATOR);
+    }
+
+    void flushQueued(bool resetPendingCounter) {
+        ensureConnected();
+
+        while (sendOffset_ < sendBuffer_.size()) {
+            const auto remaining = sendBuffer_.size() - sendOffset_;
+            const auto* dataPtr = sendBuffer_.data() + sendOffset_;
+            const auto sent = ::send(socketFd_, dataPtr, remaining, sendFlags());
+            if (sent == -1) {
+                if (errno == EINTR) {
+                    continue;
+                }
+                throw std::system_error(errno, std::system_category(), "Failed to send data to cache server");
+            }
+            sendOffset_ += static_cast<std::size_t>(sent);
+        }
+
+        if (!sendBuffer_.empty()) {
+            sendBuffer_.clear();
+        }
+        sendOffset_ = 0;
+
+        if (!queuedRequests_.empty()) {
+            inflightRequests_.insert(inflightRequests_.end(), queuedRequests_.begin(), queuedRequests_.end());
+            queuedRequests_.clear();
+        }
+
+        if (resetPendingCounter) {
+            queuedCommandCount_ = 0;
+        }
+    }
+
+    void ensureNoConflictingReads(std::string_view key) {
+        std::unordered_set<RequestId> pendingGets;
+        pendingGets.reserve(queuedRequests_.size() + inflightRequests_.size());
+
+        bool flushNeeded = false;
+        for (const auto& request : queuedRequests_) {
+            if (request.type == RequestType::Get && request.key == key) {
+                pendingGets.insert(request.id);
+                flushNeeded = true;
+            }
+        }
+
+        if (flushNeeded) {
+            flushQueued(false);
+        }
+
+        for (const auto& request : inflightRequests_) {
+            if (request.type == RequestType::Get && request.key == key) {
+                if (completedResponses_.find(request.id) == completedResponses_.end()) {
+                    pendingGets.insert(request.id);
+                }
+            }
+        }
+
+        for (auto it = pendingGets.begin(); it != pendingGets.end();) {
+            if (completedResponses_.find(*it) != completedResponses_.end()) {
+                it = pendingGets.erase(it);
+            } else {
+                ++it;
+            }
+        }
+
+        while (!pendingGets.empty()) {
+            Response response = receiveResponse();
+            RequestId responseId = response.requestId;
+            completedResponses_[responseId] = std::move(response);
+            pendingGets.erase(responseId);
+        }
+    }
+
+    void ensureFlushedFor(RequestId id) {
+        const auto it = std::find_if(queuedRequests_.begin(), queuedRequests_.end(),
+                                     [id](const PendingRequest& pending) { return pending.id == id; });
+        if (it != queuedRequests_.end()) {
+            flushQueued(false);
+        }
+    }
+
+    [[nodiscard]] std::optional<Response> tryParseResponse() {
+        const auto it = std::find(receiveBuffer_.begin(), receiveBuffer_.end(), MSG_SEPARATOR);
+        if (it == receiveBuffer_.end()) {
+            return std::nullopt;
+        }
+
+        const auto messageEnd = static_cast<std::size_t>(std::distance(receiveBuffer_.begin(), it));
+        std::string message(receiveBuffer_.data(), messageEnd);
+        receiveBuffer_.erase(receiveBuffer_.begin(), it + 1);
+
+        if (inflightRequests_.empty()) {
+            throw std::logic_error("Received response without pending request");
+        }
+
+        const PendingRequest pending = inflightRequests_.front();
+        inflightRequests_.pop_front();
+
+        Response response;
+        response.requestId = pending.id;
+        response.requestType = pending.type;
+        response.result = interpretResult(pending.type, message);
+
+        switch (response.result) {
+            case ResultCode::Ok:
+                if (pending.type == RequestType::Get) {
+                    response.value = std::move(message);
+                } else {
+                    response.value.clear();
+                }
+                response.errorMessage.clear();
+                break;
+            case ResultCode::NotFound:
+                response.value.clear();
+                response.errorMessage.clear();
+                break;
+            case ResultCode::Error:
+                response.value.clear();
+                response.errorMessage = std::move(message);
+                break;
+        }
+
+        return response;
+    }
+
+    static ResultCode interpretResult(RequestType type, const std::string& message) {
+        if (message.rfind("ERROR:", 0) == 0) {
+            if (type == RequestType::Delete && message == KEY_NOT_EXISTS) {
+                return ResultCode::NotFound;
+            }
+            return ResultCode::Error;
+        }
+
+        if (type == RequestType::Get && message == NOTHING) {
+            return ResultCode::NotFound;
+        }
+
+        return ResultCode::Ok;
+    }
+
+    [[nodiscard]] std::optional<Response> popCompleted(RequestId id) {
+        auto it = completedResponses_.find(id);
+        if (it == completedResponses_.end()) {
+            return std::nullopt;
+        }
+        Response response = std::move(it->second);
+        completedResponses_.erase(it);
+        return response;
+    }
+
+    static void validateKey(std::string_view key) {
+        if (key.empty()) {
+            throw std::invalid_argument("Key must not be empty");
+        }
+        if (key.find(' ') != std::string_view::npos) {
+            throw std::invalid_argument("Keys containing spaces are not supported by the protocol");
+        }
+        if (key.find(MSG_SEPARATOR) != std::string_view::npos) {
+            throw std::invalid_argument("Key contains protocol separator character");
+        }
+    }
+
+    void moveFrom(CacheClient&& other) noexcept {
+        options_ = std::move(other.options_);
+        socketFd_ = std::exchange(other.socketFd_, -1);
+        queuedRequests_ = std::move(other.queuedRequests_);
+        inflightRequests_ = std::move(other.inflightRequests_);
+        queuedCommandCount_ = other.queuedCommandCount_;
+        completedResponses_ = std::move(other.completedResponses_);
+        sendBuffer_ = std::move(other.sendBuffer_);
+        sendOffset_ = other.sendOffset_;
+        other.sendOffset_ = 0;
+        receiveBuffer_ = std::move(other.receiveBuffer_);
+        nextRequestId_ = other.nextRequestId_;
+        other.nextRequestId_ = 1;
+        other.queuedRequests_.clear();
+        other.inflightRequests_.clear();
+        other.queuedCommandCount_ = 0;
+    }
+};
+
+} // namespace pmc
+

--- a/tests/client_integration/Dockerfile
+++ b/tests/client_integration/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:3.19
+
+RUN apk add --no-cache build-base
+
+WORKDIR /app
+
+COPY src/client/cache_client.hpp src/client/cache_client.hpp
+COPY tests/client_integration/client_integration_test.cpp client_integration_test.cpp
+
+RUN g++ -std=c++20 -Wall -Wextra -Werror -pedantic -O2 -pthread -Isrc client_integration_test.cpp -o client_integration_test
+
+ENTRYPOINT ["/app/client_integration_test"]

--- a/tests/client_integration/client_integration_test.cpp
+++ b/tests/client_integration/client_integration_test.cpp
@@ -1,0 +1,129 @@
+#include "client/cache_client.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <random>
+#include <sstream>
+#include <string>
+#include <thread>
+
+namespace {
+
+[[noreturn]] void fail(const std::string& message) {
+    std::cerr << "[client-integration] " << message << std::endl;
+    std::exit(EXIT_FAILURE);
+}
+
+void expect(bool condition, const std::string& message) {
+    if (!condition) {
+        fail(message);
+    }
+}
+
+std::string randomSuffix() {
+    std::random_device rd;
+    std::mt19937_64 gen(rd());
+    std::uniform_int_distribution<std::uint64_t> dist;
+    std::ostringstream oss;
+    oss << std::hex << dist(gen);
+    return oss.str();
+}
+
+void connectWithRetry(pmc::CacheClient& client, int maxAttempts = 20) {
+    using namespace std::chrono_literals;
+    for (int attempt = 1; attempt <= maxAttempts; ++attempt) {
+        try {
+            client.connect();
+            return;
+        } catch (const std::exception& ex) {
+            if (attempt == maxAttempts) {
+                std::ostringstream oss;
+                oss << "Failed to connect to cache server after " << maxAttempts
+                    << " attempts: " << ex.what();
+                fail(oss.str());
+            }
+            std::this_thread::sleep_for(250ms);
+        }
+    }
+}
+
+} // namespace
+
+int main() {
+    const char* hostEnv = std::getenv("CACHE_HOST");
+    const char* portEnv = std::getenv("CACHE_PORT");
+
+    pmc::CacheClient::Options options;
+    options.host = hostEnv ? hostEnv : "127.0.0.1";
+    if (portEnv != nullptr) {
+        options.port = static_cast<std::uint16_t>(std::stoi(portEnv));
+    }
+
+    pmc::CacheClient client(options);
+    connectWithRetry(client);
+
+    const std::string keyPrefix = std::string("cpp-client-it-") + randomSuffix();
+    const std::string key1 = keyPrefix + "-k1";
+    const std::string key2 = keyPrefix + "-k2";
+    const std::string value1 = "value-1";
+    const std::string value2 = "value-2";
+
+    // Basic CRUD semantics.
+    {
+        auto getMissing = client.get(key1);
+        expect(getMissing.notFound(), "Expected missing key to return NotFound");
+
+        auto setResponse = client.set(key1, value1);
+        expect(setResponse.ok(), "SET should return OK result");
+
+        auto getResponse = client.get(key1);
+        expect(getResponse.ok(), "GET after SET should succeed");
+        expect(getResponse.value == value1, "GET should return the stored value");
+
+        auto delResponse = client.del(key1);
+        expect(delResponse.ok(), "DEL should return OK for existing key");
+
+        auto getDeleted = client.get(key1);
+        expect(getDeleted.notFound(), "GET after DEL should return NotFound");
+    }
+
+    // Verify pipelining helpers and response bookkeeping work correctly.
+    {
+        const auto setFooId = client.enqueueSet(key1, value1);
+        const auto setBarId = client.enqueueSet(key2, value2);
+        const auto getFooId = client.enqueueGet(key1);
+        const auto getBarId = client.enqueueGet(key2);
+        const auto delFooId = client.enqueueDelete(key1);
+
+        expect(client.pendingRequestCount() == 5, "All commands should be pending before flush");
+        client.flush();
+        expect(client.pendingRequestCount() == 0, "No commands should remain pending after flush");
+
+        // Wait for responses in an order different from their submission to ensure
+        // cached responses are surfaced correctly.
+        auto getFoo = client.waitFor(getFooId);
+        expect(getFoo.ok(), "GET response should be OK");
+        expect(getFoo.value == value1, "GET response should contain latest value");
+
+        auto setFoo = client.waitFor(setFooId);
+        expect(setFoo.ok(), "Queued SET response should be cached and retrievable");
+
+        auto setBar = client.waitFor(setBarId);
+        expect(setBar.ok(), "Second SET response should be OK");
+
+        auto getBar = client.waitFor(getBarId);
+        expect(getBar.ok(), "GET for second key should succeed");
+        expect(getBar.value == value2, "GET for second key should return stored value");
+
+        auto delFoo = client.waitFor(delFooId);
+        expect(delFoo.ok(), "DEL should return OK for existing key");
+
+        auto finalGet = client.get(key1);
+        expect(finalGet.notFound(), "Key should be missing after deletion");
+    }
+
+    std::cout << "Client integration test completed successfully" << std::endl;
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary
- drain queued GET responses before enqueuing conflicting SET/DEL operations so later mutations cannot invalidate returned values
- add internal flushing and request bookkeeping to preserve user-facing pending counts while guaranteeing responses remain cached

## Testing
- cmake --build out/build/Release
- CACHE_HOST=127.0.0.1 CACHE_PORT=9001 /tmp/client_integration_test

------
https://chatgpt.com/codex/tasks/task_e_68e2a92930fc8333a6da29fd06a269e0