### PR TITLE
Add support for basic RESP protocol

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,14 @@ jobs:
       run: docker compose --profile tests-pipelined up
       timeout-minutes: 5
 
+    - name: Run load and functional tests (RESP protocol)
+      run: docker compose --profile tests-resp up
+      timeout-minutes: 10
+
+    - name: Run load and functional tests (RESP protocol, pipelined mode enabled)
+      run: docker compose --profile tests-resp-pipelined up
+      timeout-minutes: 5
+
     - name: Run load and functional tests (request-per-connection clients)
       run: docker compose --profile tests-req-per-conn up
       timeout-minutes: 10

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,10 +25,6 @@ endif ()
 find_package(prometheus-cpp CONFIG REQUIRED)
 find_package(ZLIB REQUIRED)
 
-if (WIN32)
-    add_compile_definitions(BOOST_ALL_NO_LIB)
-endif ()
-
 if(NOT DEFINED prometheus-cpp_VERSION)
   message(FATAL_ERROR "prometheus-cpp_VERSION is not defined")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,10 @@ endif ()
 find_package(prometheus-cpp CONFIG REQUIRED)
 find_package(ZLIB REQUIRED)
 
+if (WIN32)
+    add_compile_definitions(BOOST_ALL_NO_LIB)
+endif ()
+
 if(NOT DEFINED prometheus-cpp_VERSION)
   message(FATAL_ERROR "prometheus-cpp_VERSION is not defined")
 endif()

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Functional RPS is calculated based on: (T<sub>client</sub> + T<sub>server</sub>)
 Lunix kernel settings used as much as possible for both local and docker setups can be found in local_server_setup.bash
 
 ##### Local setup
-- Ubuntu (with high end processor and half gbit internet).
+- Ubuntu 24.04 kernel 6.14.0-27-generic (with high end processor and half gbit internet).
 - Docker on Ubuntu or Windows (with high end processor and half gbit internet)
 
 ##### CI setup 

--- a/README.md
+++ b/README.md
@@ -363,10 +363,9 @@ done
 - Test edge case scenarios
 - Integrate valgrind checks into CI
 - More corouties + refactor coroutine code to templates & other fancy things (if that won't hurt performance)
-- Work on error responses from cache server
+- Replace server metrics with wide observability events. Improve integration between the main server and the metrics server.
 - Support key expiration, support more operations.
 - Check if we can reduce memory usage during decompression as well.
-- Integration between the main server and the metrics server can be improved.
 - Continue improving collision resolution (endless task, tbh...).
 - Check if there are better ways of avoiding double hash calculation in the server and KVS (right now we just provide extra public methods in `kvs.cpp` which accept hash as an argument).
 - There is an opportunity to try out Robot Framework for testing & writing test cases (I've never used that tool). OR just use [Cucumber for Golang aka Godog](https://github.com/cucumber/godog) tests, which I know.

--- a/README.md
+++ b/README.md
@@ -376,10 +376,6 @@ done
 - Read http://www.kegel.com/c10k.html
 - Continue reading https://www.chiark.greenend.org.uk/~sgtatham/quasiblog/coroutines-c++20/
 
-## Questions / Ideas
-- add support for RESP protocol?
-
-
 ## Good articles and guidelines
 - https://beej.us/guide/bgnet/html/#close-and-shutdownget-outta-my-face
 - https://idea.popcount.org/2017-02-20-epoll-is-fundamentally-broken-12/

--- a/docker-compose-local.yaml
+++ b/docker-compose-local.yaml
@@ -69,6 +69,33 @@ services:
     networks:
       - cache_network
 
+  tests-resp:
+    extends:
+      file: common-compose-config.yaml
+      service: tests-common
+    environment:
+      - TEST_ITERATIONS=1000000
+      - CACHE_HOST=cache
+      - CACHE_TYPE=resp
+    profiles:
+      - tests-resp
+    networks:
+      - cache_network
+    command: ["tcp_server_test.py", "--resp"]
+
+  tests-resp-pipelined:
+    extends:
+      file: common-compose-config.yaml
+      service: tests-common
+    environment:
+      - CACHE_HOST=cache
+      - CACHE_TYPE=resp
+    profiles:
+      - tests-resp-pipelined
+    networks:
+      - cache_network
+    command: ["tcp_server_test.py", "--resp", "-p"]
+
   tests-valgrind:
     extends:
       file: common-compose-config.yaml

--- a/docker-compose.yaml.j2
+++ b/docker-compose.yaml.j2
@@ -51,6 +51,32 @@ services:
       - cache_network
     command: ["tcp_server_test.py", "-p"]
 
+  tests-resp:
+    extends:
+      file: common-compose-config.yaml
+      service: tests-common
+    environment:
+      - CACHE_HOST=cache
+      - CACHE_TYPE=resp
+    profiles:
+      - tests-resp
+    networks:
+      - cache_network
+    command: ["tcp_server_test.py", "--resp"]
+
+  tests-resp-pipelined:
+    extends:
+      file: common-compose-config.yaml
+      service: tests-common
+    environment:
+      - CACHE_HOST=cache
+      - CACHE_TYPE=resp
+    profiles:
+      - tests-resp-pipelined
+    networks:
+      - cache_network
+    command: ["tcp_server_test.py", "--resp", "-p"]
+
   tests-req-per-conn:
     extends:
       file: common-compose-config.yaml

--- a/run-all-tests.bash
+++ b/run-all-tests.bash
@@ -4,12 +4,20 @@ echo 'Building all tests...'
 cd ./src
 g++ -std=c++23 -O3 -s -DNDEBUG -pthread -I/usr/include/ -I/usr/local/include/ -L/usr/lib/ hash/*.cpp compressor/gzip_compressor.cpp kvs/*.cpp primegen/primegen.cpp -lz -lgtest -lgtest_main -o ../kvs_test
 g++ -std=c++23 -O3 -s -DNDEBUG -pthread -I/usr/include/ -I/usr/local/include/ compressor/*.cpp -lz -lgtest -lgtest_main -o ../test_gzip
+g++ -std=c++23 -O3 -s -DNDEBUG -pthread -I/usr/include/ -I/usr/local/include/ server/protocol.cpp server/protocol_test.cpp -lgtest -lgtest_main -o ../protocol_test
 cd ..
 
 export NUM_ELEMENTS=10000000
 echo 'Running kvs tests...'
 
 ./kvs_test
+if [ $? -ne 0 ]; then
+ exit $?
+fi
+
+echo 'Running protocol tests...'
+
+./protocol_test
 if [ $? -ne 0 ]; then
  exit $?
 fi

--- a/run-all-tests.bash
+++ b/run-all-tests.bash
@@ -1,29 +1,25 @@
 #!/bin/bash
+set -euo pipefail
+
 echo 'Building all tests...'
 
-cd ./src
+pushd ./src > /dev/null
 g++ -std=c++23 -O3 -s -DNDEBUG -pthread -I/usr/include/ -I/usr/local/include/ -L/usr/lib/ hash/*.cpp compressor/gzip_compressor.cpp kvs/*.cpp primegen/primegen.cpp -lz -lgtest -lgtest_main -o ../kvs_test
 g++ -std=c++23 -O3 -s -DNDEBUG -pthread -I/usr/include/ -I/usr/local/include/ compressor/*.cpp -lz -lgtest -lgtest_main -o ../test_gzip
 g++ -std=c++23 -O3 -s -DNDEBUG -pthread -I/usr/include/ -I/usr/local/include/ server/protocol.cpp server/protocol_test.cpp -lgtest -lgtest_main -o ../protocol_test
-cd ..
+popd > /dev/null
 
 export NUM_ELEMENTS=10000000
 echo 'Running kvs tests...'
 
 ./kvs_test
-if [ $? -ne 0 ]; then
- exit $?
-fi
 
 echo 'Running protocol tests...'
 
 ./protocol_test
-if [ $? -ne 0 ]; then
- exit $?
-fi
 
 echo 'Running gzip tests...'
 
 ./test_gzip
 
-exit $?
+echo 'All tests completed successfully.'

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(
   ${PROJECT_NAME} 
   main.cpp
   server/coroutines.cpp
+  server/protocol.cpp
   server/server.cpp
   server/shard.cpp
   server/conn_manager.hpp

--- a/src/env.hpp
+++ b/src/env.hpp
@@ -31,7 +31,7 @@ T getFromEnv(const char* env_var_name, bool isRequired, T defaultVal = T()) {
     }
 
     if (isRequired) {
-        std::cerr << "Environment variable " << env_var_name << " not found." << std::endl;
+        std::cerr << "Environment variable " << env_var_name << " not found.\n";
         std::exit(1);
     }
 

--- a/src/kvs/kvs.cpp
+++ b/src/kvs/kvs.cpp
@@ -18,7 +18,7 @@ KeyValueStore::KeyValueStore(KeyValueStoreSettings settings)
     table = new Bucket[tableSize];
     initializeTable(table, tableSize);
 #ifndef NDEBUG
-    std::cout << "Table initialization finished!" << std::endl;
+    std::cout << "Table initialization finished!\n";
 #endif
 }
 
@@ -51,7 +51,7 @@ inline void KeyValueStore::cleanTable(Bucket *tableToDelete, uint_fast64_t size)
         }
         delete[] tableToDelete;
 #ifndef NDEBUG
-        std::cout << "Table cleanup finished!" << std::endl;
+        std::cout << "Table cleanup finished!\n";
 #endif
     }
 
@@ -168,7 +168,7 @@ bool KeyValueStore::set(const char *key, const char *value, uint_fast64_t hash) 
     } while (attempt < MAX_READ_WRITE_ATTEMPTS);
 
 #ifndef NDEBUG
-    std::cerr << "Failed to insert key = " << key << " after " << attempt << " attempts." << std::endl;
+    std::cerr << "Failed to insert key = " << key << " after " << attempt << " attempts.\n";
 #endif
     return false;
 }
@@ -267,7 +267,7 @@ bool kvs::KeyValueStore::del(const char *key, uint_fast64_t hash)
     } while (attempt < MAX_READ_WRITE_ATTEMPTS);
 
 #ifndef NDEBUG
-    std::cerr << "Failed to find key during deletion, key = " << key << " after " << attempt << " attempts." << std::endl;
+    std::cerr << "Failed to find key during deletion, key = " << key << " after " << attempt << " attempts.\n";
 #endif
     return false;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@
 using namespace server;
 
 int main() {
-    std::queue<CacheServerMetrics> serverChannel;
+    MetricsChannel serverChannel;
 
     auto metricsHost = getFromEnv<const char*>("METRICS_HOST", true);
     auto metricsPort = getFromEnv<int>("METRICS_PORT", true);
@@ -45,17 +45,16 @@ int main() {
     auto metricsUpdaterThread = std::jthread(
         [&serverChannel, &metricsServer](std::stop_token stopToken)
         {
-            std::cout << "Metrics updater thread is running!" << std::endl;
+            std::cout << "Metrics updater thread is running!\n";
             while (!stopToken.stop_requested())
             {
-                while (!serverChannel.empty()) {
-                    auto serverMetrics = serverChannel.front();
+                CacheServerMetrics serverMetrics{0, 0, 0};
+                while (serverChannel.try_pop(serverMetrics)) {
                     metricsServer.UpdateMetrics(serverMetrics);
-                    serverChannel.pop();
                 }
                 std::this_thread::sleep_for(std::chrono::seconds(2));
             }
-            std::cout << "Exiting metrics updater thread..." << std::endl;
+            std::cout << "Exiting metrics updater thread...\n";
         }
     );
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,8 +21,9 @@ int main() {
     auto sockBufferSize = getFromEnv<int>("SOCK_BUF_SIZE", false, 1048576);
     auto connQueueLimit = getFromEnv<uint_fast32_t>("CONN_QUEUE_LIMIT", false, 1048576);
     auto enableCompression = getFromEnv<bool>("ENABLE_COMPRESSION", false, true);
+    auto respInlineCapacity = getFromEnv<std::size_t>("RESP_INLINE_CAPACITY", false, static_cast<std::size_t>(255));
 
-    ServerSettings serverSettings { serverPort, numShards, sockBufferSize, connQueueLimit, enableCompression };
+    ServerSettings serverSettings { serverPort, numShards, sockBufferSize, connQueueLimit, enableCompression, respInlineCapacity };
 
     CacheServer cacheServer { serverSettings };
 

--- a/src/metrics/metrics.cpp
+++ b/src/metrics/metrics.cpp
@@ -31,12 +31,6 @@ void MetricsServer::RegisterMetrics()
                         .Help("Total number of server requests")
                         .Register(*registry)
                         .Add({});
-
-    server_events_per_batch = &BuildGauge()
-                        .Name("server_events_per_batch")
-                        .Help("Number of processed events per batch")
-                        .Register(*registry)
-                        .Add({});
 }
 
 MetricsServer::MetricsServer(std::string metrics_url)
@@ -51,7 +45,6 @@ MetricsServer::MetricsServer(std::string metrics_url)
 void MetricsServer::UpdateMetrics(CacheServerMetrics& serverMetrics)
 {
     server_num_active_connections->Set(serverMetrics.numActiveConnections);
-    server_events_per_batch->Set(serverMetrics.eventsPerBatch);
 
     auto numErrorsInc = serverMetrics.numErrors - server_num_errors_total->Value();
     server_num_errors_total->Increment(numErrorsInc);

--- a/src/metrics/metrics.hpp
+++ b/src/metrics/metrics.hpp
@@ -20,7 +20,6 @@ namespace metrics
             std::shared_ptr<Exposer> server;
 
             Gauge* server_num_active_connections = nullptr;
-            Gauge* server_events_per_batch = nullptr;
             Counter* server_num_requests_total = nullptr;
             Counter* server_num_errors_total = nullptr;
 

--- a/src/primegen/primegen.cpp
+++ b/src/primegen/primegen.cpp
@@ -3,7 +3,7 @@
 void Primegen::initGenerator()
 {
     if (!isInitialized) {
-        std::cout << "Generating prime numbers queue..." << std::endl;
+        std::cout << "Generating prime numbers queue...\n";
         uint_fast64_t start = 2;
         uint_fast64_t lastStored = 2053;
         double growthFactor = 2.0;
@@ -50,7 +50,7 @@ void Primegen::initGenerator()
             start = end;
         }
         isInitialized = true;
-        std::cout << "Prime numbers queue is ready" << std::endl;
+        std::cout << "Prime numbers queue is ready\n";
     }
 }
 

--- a/src/server/conn_manager.hpp
+++ b/src/server/conn_manager.hpp
@@ -25,6 +25,8 @@ namespace server {
         std::vector<char> readBuffer;
         std::deque<RequestView> pendingRequests;
         size_t bytesToErase = 0;
+        bool inTransaction = false;
+        std::vector<ResponsePacket> transactionQueue;
         ConnectionData() = default;
         ConnectionData(timespec ts, int epfd) : lastActivity(ts), epoll_fd(epfd) {
             readBuffer.reserve(READ_BUFFER_SIZE);

--- a/src/server/conn_manager.hpp
+++ b/src/server/conn_manager.hpp
@@ -16,13 +16,14 @@
 #include "coroutines.hpp"
 #include "sockutils.hpp"
 #include "constants.hpp"
+#include "protocol.hpp"
 
 namespace server {
     struct ConnectionData {
         timespec lastActivity {0, 0};
         int epoll_fd = -1;
         std::vector<char> readBuffer;
-        std::deque<std::string_view> pendingRequests;
+        std::deque<RequestView> pendingRequests;
         size_t bytesToErase = 0;
         ConnectionData() = default;
         ConnectionData(timespec ts, int epfd) : lastActivity(ts), epoll_fd(epfd) {

--- a/src/server/conn_manager.hpp
+++ b/src/server/conn_manager.hpp
@@ -159,7 +159,13 @@ namespace server {
 #endif
                 }
                 connections.erase(fd);
-                --activeConnectionsCounter;
+                if (activeConnectionsCounter > 0) {
+                    --activeConnectionsCounter;
+                } else {
+#ifndef NDEBUG
+                    std::cout << "Attempt to decrease activeConnectionsCounter = 0\n";
+#endif
+                }
             };
 
             void acceptConnections(int server_fd, std::stop_token stopToken) {

--- a/src/server/protocol.cpp
+++ b/src/server/protocol.cpp
@@ -1,6 +1,48 @@
 #include "protocol.hpp"
 
 namespace server {
+
+static inline bool is_digit(char c) noexcept {
+    return (c >= '0') && (c <= '9');
+}
+
+static inline bool read_crlf_decimal(const char* data, size_t end, size_t& idx, size_t& out) noexcept {
+    size_t val = 0;
+    bool any = false;
+
+    while (idx < end) {
+        const char c = data[idx];
+        if (c == RESP_CR) {
+            if (idx + 1 >= end || data[idx + 1] != RESP_LF || !any) return false;
+            idx += 2;
+            out = val;
+            return true;
+        }
+        if (!is_digit(c)) return false;
+        any = true;
+        val = val * 10 + static_cast<size_t>(c - '0');
+        ++idx;
+    }
+    return false;
+}
+
+static inline unsigned u64_to_ascii(size_t v, char* out) noexcept {
+    char buf[20];
+    unsigned n = 0;
+    do {
+        const size_t q = v / 10;
+        const unsigned r = static_cast<unsigned>(v - q * 10);
+        buf[n++] = static_cast<char>('0' + r);
+        v = q;
+    } while (v);
+
+    for (unsigned i = 0, j = n - 1; i < j; ++i, --j) {
+        const char t = buf[i]; buf[i] = buf[j]; buf[j] = t;
+    }
+    std::memcpy(out, buf, n);
+    return n;
+}
+
 RespParseResult parseRespMessageLength(const std::vector<char>& buffer, size_t start)
 {
     size_t idx = start;
@@ -9,94 +51,56 @@ RespParseResult parseRespMessageLength(const std::vector<char>& buffer, size_t s
     if (idx >= end || buffer[idx] != RESP_ARRAY_PREFIX) {
         return {RespParseStatus::Error, 0};
     }
-
     ++idx;
+
     size_t arrayLen = 0;
-    bool hasDigits = false;
-
-    while (idx < end) {
-        const char c = buffer[idx];
-        if (c == RESP_CR) {
-            if (idx + 1 >= end) {
-                return {RespParseStatus::Incomplete, 0};
-            }
-
-            if (buffer[idx + 1] != RESP_LF || !hasDigits) {
-                return {RespParseStatus::Error, 0};
-            }
-
-            idx += 2;
-            break;
-        }
-
-        if (!std::isdigit(static_cast<unsigned char>(c))) {
-            return {RespParseStatus::Error, 0};
-        }
-
-        hasDigits = true;
-        arrayLen = arrayLen * 10 + static_cast<size_t>(c - '0');
-        ++idx;
-    }
-
-    if (!hasDigits) {
-        return {RespParseStatus::Error, 0};
-    }
-
-    for (size_t arg = 0; arg < arrayLen; ++arg) {
-        if (idx >= end) {
-            return {RespParseStatus::Incomplete, 0};
-        }
-
-        if (buffer[idx] != RESP_BULK_PREFIX) {
-            return {RespParseStatus::Error, 0};
-        }
-
-        ++idx;
-        size_t bulkLen = 0;
-        bool lenDigits = false;
-
+    {
+        bool any = false;
         while (idx < end) {
             const char c = buffer[idx];
             if (c == RESP_CR) {
-                if (idx + 1 >= end) {
-                    return {RespParseStatus::Incomplete, 0};
-                }
-
-                if (buffer[idx + 1] != RESP_LF || !lenDigits) {
+                if (idx + 1 >= end || buffer[idx + 1] != RESP_LF || !any) {
                     return {RespParseStatus::Error, 0};
                 }
-
                 idx += 2;
                 break;
             }
-
-            if (!std::isdigit(static_cast<unsigned char>(c))) {
-                return {RespParseStatus::Error, 0};
-            }
-
-            lenDigits = true;
-            bulkLen = bulkLen * 10 + static_cast<size_t>(c - '0');
+            if (!is_digit(c)) return {RespParseStatus::Error, 0};
+            any = true;
+            arrayLen = arrayLen * 10 + static_cast<size_t>(c - '0');
             ++idx;
         }
+        if (!any) return {RespParseStatus::Error, 0};
+    }
 
-        if (!lenDigits) {
-            return {RespParseStatus::Error, 0};
+    for (size_t arg = 0; arg < arrayLen; ++arg) {
+        if (idx >= end) return {RespParseStatus::Incomplete, 0};
+        if (buffer[idx] != RESP_BULK_PREFIX) return {RespParseStatus::Error, 0};
+        ++idx;
+
+        size_t bulkLen = 0;
+        {
+            bool any = false;
+            while (idx < end) {
+                const char c = buffer[idx];
+                if (c == RESP_CR) {
+                    if (idx + 1 >= end || buffer[idx + 1] != RESP_LF || !any) {
+                        return {RespParseStatus::Error, 0};
+                    }
+                    idx += 2;
+                    break;
+                }
+                if (!is_digit(c)) return {RespParseStatus::Error, 0};
+                any = true;
+                bulkLen = bulkLen * 10 + static_cast<size_t>(c - '0');
+                ++idx;
+            }
+            if (!any) return {RespParseStatus::Error, 0};
         }
 
-        if (idx + bulkLen + 2 > end) {
-            return {RespParseStatus::Incomplete, 0};
-        }
-
+        if (idx + bulkLen + 2 > end) return {RespParseStatus::Incomplete, 0};
         idx += bulkLen;
-
-        if (idx + 1 >= end) {
-            return {RespParseStatus::Incomplete, 0};
-        }
-
-        if (buffer[idx] != RESP_CR || buffer[idx + 1] != RESP_LF) {
-            return {RespParseStatus::Error, 0};
-        }
-
+        if (buffer[idx] != RESP_CR || buffer[idx + 1] != RESP_LF) return {RespParseStatus::Error, 0};
         idx += 2;
     }
 
@@ -105,80 +109,36 @@ RespParseResult parseRespMessageLength(const std::vector<char>& buffer, size_t s
 
 bool parseRespCommand(std::string_view payload, RespCommandParts& parts)
 {
-    if (payload.empty() || payload.front() != RESP_ARRAY_PREFIX) {
-        return false;
-    }
+    if (payload.empty() || payload.front() != RESP_ARRAY_PREFIX) return false;
 
-    auto* data = const_cast<char*>(payload.data());
+    char* data = const_cast<char*>(payload.data());
     size_t idx = 1;
     const size_t end = payload.size();
 
-    auto readNumber = [&](size_t& out) -> bool {
-        if (idx >= end) {
-            return false;
-        }
-
-        size_t value = 0;
-        bool hasDigits = false;
-
-        while (idx < end) {
-            const char c = data[idx];
-            if (c == RESP_CR) {
-                if (idx + 1 >= end || data[idx + 1] != RESP_LF || !hasDigits) {
-                    return false;
-                }
-
-                idx += 2;
-                out = value;
-                return true;
-            }
-
-            if (!std::isdigit(static_cast<unsigned char>(c))) {
-                return false;
-            }
-
-            hasDigits = true;
-            value = value * 10 + static_cast<size_t>(c - '0');
-            ++idx;
-        }
-
-        return false;
+    auto read_num = [&](size_t& out) -> bool {
+        return read_crlf_decimal(data, end, idx, out);
     };
 
     size_t elements = 0;
-    if (!readNumber(elements) || elements < 2 || elements > 3) {
-        return false;
-    }
+    if (!read_num(elements) || elements < 2 || elements > 3) return false;
 
     for (size_t i = 0; i < elements; ++i) {
-        if (idx >= end || data[idx] != RESP_BULK_PREFIX) {
-            return false;
-        }
-
+        if (idx >= end || data[idx] != RESP_BULK_PREFIX) return false;
         ++idx;
 
         size_t len = 0;
-        if (!readNumber(len) || idx + len + 2 > end) {
-            return false;
-        }
+        if (!read_num(len) || idx + len + 2 > end) return false;
 
         char* startPtr = data + idx;
         idx += len;
 
-        if (idx + 1 >= end || data[idx] != RESP_CR || data[idx + 1] != RESP_LF) {
-            return false;
-        }
-
+        if (idx + 1 >= end || data[idx] != RESP_CR || data[idx + 1] != RESP_LF) return false;
         data[idx] = '\0';
         idx += 2;
 
-        if (i == 0) {
-            parts.command = startPtr;
-        } else if (i == 1) {
-            parts.key = startPtr;
-        } else if (i == 2) {
-            parts.value = startPtr;
-        }
+        if (i == 0)       parts.command = startPtr;
+        else if (i == 1)  parts.key     = startPtr;
+        else              parts.value   = startPtr;
     }
 
     parts.argc = elements;
@@ -198,18 +158,18 @@ ResponsePacket makeRespSimpleString(const char* message)
 {
     ResponsePacket response{};
     response.protocol = RequestProtocol::RESP;
+
     const size_t len = std::strlen(message);
     auto buffer = std::unique_ptr<char[]>(new char[len + 3]);
+    char* out = buffer.get();
 
-    buffer[0] = RESP_SIMPLE_PREFIX;
-    if (len > 0) {
-        std::memcpy(buffer.get() + 1, message, len);
-    }
-    buffer[len + 1] = RESP_CR;
-    buffer[len + 2] = RESP_LF;
+    out[0] = RESP_SIMPLE_PREFIX;
+    if (len) std::memcpy(out + 1, message, len);
+    out[len + 1] = RESP_CR;
+    out[len + 2] = RESP_LF;
 
-    response.size = len + 3;
-    response.data = buffer.get();
+    response.size  = len + 3;
+    response.data  = out;
     response.owned = std::move(buffer);
     return response;
 }
@@ -226,28 +186,23 @@ ResponsePacket makeRespBulkString(const char* value)
     }
 
     const size_t len = std::strlen(value);
-    char lenBuf[32];
-    auto res = std::to_chars(lenBuf, lenBuf + sizeof(lenBuf), len);
-    const size_t digits = static_cast<size_t>(res.ptr - lenBuf);
+    char lenBuf[20];
+    const unsigned digits = u64_to_ascii(len, lenBuf);
 
-    const size_t total = digits + len + 5;
+    const size_t total = 1 + digits + 2 + len + 2;
     auto buffer = std::unique_ptr<char[]>(new char[total]);
     char* out = buffer.get();
 
     out[0] = RESP_BULK_PREFIX;
-    if (digits > 0) {
-        std::memcpy(out + 1, lenBuf, digits);
-    }
+    if (digits) std::memcpy(out + 1, lenBuf, digits);
     out[1 + digits] = RESP_CR;
     out[2 + digits] = RESP_LF;
-    if (len > 0) {
-        std::memcpy(out + 3 + digits, value, len);
-    }
+    if (len) std::memcpy(out + 3 + digits, value, len);
     out[3 + digits + len] = RESP_CR;
     out[4 + digits + len] = RESP_LF;
 
-    response.size = total;
-    response.data = buffer.get();
+    response.size  = total;
+    response.data  = out;
     response.owned = std::move(buffer);
     return response;
 }
@@ -257,32 +212,26 @@ ResponsePacket makeRespError(const char* message)
     ResponsePacket response{};
     response.protocol = RequestProtocol::RESP;
 
-    const size_t msgLen = std::strlen(message);
     const size_t prefixLen = sizeof(RESP_ERROR_PREFIX) - 1;
+    const size_t msgLen    = std::strlen(message);
     auto buffer = std::unique_ptr<char[]>(new char[prefixLen + msgLen + 2]);
     char* out = buffer.get();
 
-    if (prefixLen > 0) {
-        std::memcpy(out, RESP_ERROR_PREFIX, prefixLen);
-    }
-    if (msgLen > 0) {
-        std::memcpy(out + prefixLen, message, msgLen);
-    }
-    out[prefixLen + msgLen] = RESP_CR;
+    if (prefixLen) std::memcpy(out, RESP_ERROR_PREFIX, prefixLen);
+    if (msgLen)    std::memcpy(out + prefixLen, message, msgLen);
+    out[prefixLen + msgLen]     = RESP_CR;
     out[prefixLen + msgLen + 1] = RESP_LF;
 
-    response.size = prefixLen + msgLen + 2;
-    response.data = buffer.get();
+    response.size  = prefixLen + msgLen + 2;
+    response.data  = out;
     response.owned = std::move(buffer);
     return response;
 }
 
 ResponsePacket makeErrorResponse(RequestProtocol protocol, const char* message)
 {
-    if (protocol == RequestProtocol::RESP) {
-        return makeRespError(message);
-    }
+    if (protocol == RequestProtocol::RESP) return makeRespError(message);
     return makeCustomResponse(message);
 }
 
-} // namespace server
+}

--- a/src/server/protocol.cpp
+++ b/src/server/protocol.cpp
@@ -1,8 +1,4 @@
 #include "protocol.hpp"
-#include <array>
-#include <limits>
-#include <atomic>
-#include <memory>
 
 namespace server {
     const char MULTI_STR[] = "MULTI";

--- a/src/server/protocol.cpp
+++ b/src/server/protocol.cpp
@@ -1,0 +1,295 @@
+#include "protocol.hpp"
+
+namespace server {
+namespace {
+    constexpr char RESP_SIMPLE_PREFIX = '+';
+    constexpr char RESP_BULK_PREFIX = '$';
+    constexpr char RESP_ERROR_PREFIX[] = "-ERR ";
+    constexpr char RESP_NULL_BULK[] = "$-1\r\n";
+}
+
+RespParseResult parseRespMessageLength(const std::vector<char>& buffer, size_t start)
+{
+    size_t idx = start;
+    const size_t end = buffer.size();
+
+    if (idx >= end || buffer[idx] != '*') {
+        return {RespParseStatus::Error, 0};
+    }
+
+    ++idx;
+    size_t arrayLen = 0;
+    bool hasDigits = false;
+
+    while (idx < end) {
+        const char c = buffer[idx];
+        if (c == '\r') {
+            if (idx + 1 >= end) {
+                return {RespParseStatus::Incomplete, 0};
+            }
+
+            if (buffer[idx + 1] != '\n' || !hasDigits) {
+                return {RespParseStatus::Error, 0};
+            }
+
+            idx += 2;
+            break;
+        }
+
+        if (!std::isdigit(static_cast<unsigned char>(c))) {
+            return {RespParseStatus::Error, 0};
+        }
+
+        hasDigits = true;
+        arrayLen = arrayLen * 10 + static_cast<size_t>(c - '0');
+        ++idx;
+    }
+
+    if (!hasDigits) {
+        return {RespParseStatus::Error, 0};
+    }
+
+    for (size_t arg = 0; arg < arrayLen; ++arg) {
+        if (idx >= end) {
+            return {RespParseStatus::Incomplete, 0};
+        }
+
+        if (buffer[idx] != RESP_BULK_PREFIX) {
+            return {RespParseStatus::Error, 0};
+        }
+
+        ++idx;
+        size_t bulkLen = 0;
+        bool lenDigits = false;
+
+        while (idx < end) {
+            const char c = buffer[idx];
+            if (c == '\r') {
+                if (idx + 1 >= end) {
+                    return {RespParseStatus::Incomplete, 0};
+                }
+
+                if (buffer[idx + 1] != '\n' || !lenDigits) {
+                    return {RespParseStatus::Error, 0};
+                }
+
+                idx += 2;
+                break;
+            }
+
+            if (!std::isdigit(static_cast<unsigned char>(c))) {
+                return {RespParseStatus::Error, 0};
+            }
+
+            lenDigits = true;
+            bulkLen = bulkLen * 10 + static_cast<size_t>(c - '0');
+            ++idx;
+        }
+
+        if (!lenDigits) {
+            return {RespParseStatus::Error, 0};
+        }
+
+        if (idx + bulkLen + 2 > end) {
+            return {RespParseStatus::Incomplete, 0};
+        }
+
+        idx += bulkLen;
+
+        if (idx + 1 >= end) {
+            return {RespParseStatus::Incomplete, 0};
+        }
+
+        if (buffer[idx] != '\r' || buffer[idx + 1] != '\n') {
+            return {RespParseStatus::Error, 0};
+        }
+
+        idx += 2;
+    }
+
+    return {RespParseStatus::Complete, idx - start};
+}
+
+bool parseRespCommand(std::string_view payload, RespCommandParts& parts)
+{
+    if (payload.empty() || payload.front() != '*') {
+        return false;
+    }
+
+    auto* data = const_cast<char*>(payload.data());
+    size_t idx = 1;
+    const size_t end = payload.size();
+
+    auto readNumber = [&](size_t& out) -> bool {
+        if (idx >= end) {
+            return false;
+        }
+
+        size_t value = 0;
+        bool hasDigits = false;
+
+        while (idx < end) {
+            const char c = data[idx];
+            if (c == '\r') {
+                if (idx + 1 >= end || data[idx + 1] != '\n' || !hasDigits) {
+                    return false;
+                }
+
+                idx += 2;
+                out = value;
+                return true;
+            }
+
+            if (!std::isdigit(static_cast<unsigned char>(c))) {
+                return false;
+            }
+
+            hasDigits = true;
+            value = value * 10 + static_cast<size_t>(c - '0');
+            ++idx;
+        }
+
+        return false;
+    };
+
+    size_t elements = 0;
+    if (!readNumber(elements) || elements < 2 || elements > 3) {
+        return false;
+    }
+
+    for (size_t i = 0; i < elements; ++i) {
+        if (idx >= end || data[idx] != RESP_BULK_PREFIX) {
+            return false;
+        }
+
+        ++idx;
+
+        size_t len = 0;
+        if (!readNumber(len) || idx + len + 2 > end) {
+            return false;
+        }
+
+        char* startPtr = data + idx;
+        idx += len;
+
+        if (idx + 1 >= end || data[idx] != '\r' || data[idx + 1] != '\n') {
+            return false;
+        }
+
+        data[idx] = '\0';
+        idx += 2;
+
+        if (i == 0) {
+            parts.command = startPtr;
+        } else if (i == 1) {
+            parts.key = startPtr;
+        } else if (i == 2) {
+            parts.value = startPtr;
+        }
+    }
+
+    parts.argc = elements;
+    return parts.command && parts.key;
+}
+
+ResponsePacket makeCustomResponse(const char* message)
+{
+    ResponsePacket response{};
+    response.protocol = RequestProtocol::Custom;
+    response.data = message;
+    response.size = std::strlen(message);
+    return response;
+}
+
+ResponsePacket makeRespSimpleString(const char* message)
+{
+    ResponsePacket response{};
+    response.protocol = RequestProtocol::RESP;
+    const size_t len = std::strlen(message);
+    auto buffer = std::unique_ptr<char[]>(new char[len + 3]);
+
+    buffer[0] = RESP_SIMPLE_PREFIX;
+    if (len > 0) {
+        std::memcpy(buffer.get() + 1, message, len);
+    }
+    buffer[len + 1] = '\r';
+    buffer[len + 2] = '\n';
+
+    response.size = len + 3;
+    response.data = buffer.get();
+    response.owned = std::move(buffer);
+    return response;
+}
+
+ResponsePacket makeRespBulkString(const char* value)
+{
+    ResponsePacket response{};
+    response.protocol = RequestProtocol::RESP;
+
+    if (value == NOTHING) {
+        response.data = RESP_NULL_BULK;
+        response.size = sizeof(RESP_NULL_BULK) - 1;
+        return response;
+    }
+
+    const size_t len = std::strlen(value);
+    char lenBuf[32];
+    auto res = std::to_chars(lenBuf, lenBuf + sizeof(lenBuf), len);
+    const size_t digits = static_cast<size_t>(res.ptr - lenBuf);
+
+    const size_t total = digits + len + 5;
+    auto buffer = std::unique_ptr<char[]>(new char[total]);
+    char* out = buffer.get();
+
+    out[0] = RESP_BULK_PREFIX;
+    if (digits > 0) {
+        std::memcpy(out + 1, lenBuf, digits);
+    }
+    out[1 + digits] = '\r';
+    out[2 + digits] = '\n';
+    if (len > 0) {
+        std::memcpy(out + 3 + digits, value, len);
+    }
+    out[3 + digits + len] = '\r';
+    out[4 + digits + len] = '\n';
+
+    response.size = total;
+    response.data = buffer.get();
+    response.owned = std::move(buffer);
+    return response;
+}
+
+ResponsePacket makeRespError(const char* message)
+{
+    ResponsePacket response{};
+    response.protocol = RequestProtocol::RESP;
+
+    const size_t msgLen = std::strlen(message);
+    const size_t prefixLen = sizeof(RESP_ERROR_PREFIX) - 1;
+    auto buffer = std::unique_ptr<char[]>(new char[prefixLen + msgLen + 2]);
+    char* out = buffer.get();
+
+    if (prefixLen > 0) {
+        std::memcpy(out, RESP_ERROR_PREFIX, prefixLen);
+    }
+    if (msgLen > 0) {
+        std::memcpy(out + prefixLen, message, msgLen);
+    }
+    out[prefixLen + msgLen] = '\r';
+    out[prefixLen + msgLen + 1] = '\n';
+
+    response.size = prefixLen + msgLen + 2;
+    response.data = buffer.get();
+    response.owned = std::move(buffer);
+    return response;
+}
+
+ResponsePacket makeErrorResponse(RequestProtocol protocol, const char* message)
+{
+    if (protocol == RequestProtocol::RESP) {
+        return makeRespError(message);
+    }
+    return makeCustomResponse(message);
+}
+
+} // namespace server

--- a/src/server/protocol.hpp
+++ b/src/server/protocol.hpp
@@ -12,7 +12,7 @@
 
 namespace server {
 
-    static const char MSG_SEPARATOR = 0x1F;
+    inline constexpr char MSG_SEPARATOR = 0x1F;
     inline constexpr char RESP_ARRAY_PREFIX = '*';
     inline constexpr char RESP_SIMPLE_PREFIX = '+';
     inline constexpr char RESP_BULK_PREFIX = '$';
@@ -21,27 +21,28 @@ namespace server {
     inline constexpr char RESP_LF = '\n';
     inline constexpr char RESP_ERROR_PREFIX[] = "-ERR ";
     inline constexpr char RESP_NULL_BULK[] = "$-1\r\n";
-    static constexpr const char* MULTI_STR = "MULTI";
-    static constexpr const char* EXEC_STR = "EXEC";
-    static constexpr const char* DISCARD_STR = "DISCARD";
-    static constexpr const char* QUEUED_STR = "QUEUED";
-    static constexpr const char* RESP_ERR_MULTI_NESTED = "ERR MULTI calls can not be nested";
-    static constexpr const char* RESP_ERR_EXEC_NO_MULTI = "ERR EXEC without MULTI";
-    static constexpr const char* RESP_ERR_DISCARD_NO_MULTI = "ERR DISCARD without MULTI";
-    static constexpr const char* RESP_ERR_EXEC_ABORTED = "EXECABORT Transaction discarded because of previous errors.";
-    static constexpr const char* OK = "OK";
-    static constexpr const char* NOTHING = "(nil)";
-    static constexpr const char* KEY_NOT_EXISTS = "ERROR: Key does not exist";
-    static constexpr const char* INTERNAL_ERROR = "ERROR: Internal error";
-    static constexpr const char* INVALID_COMMAND_CODE = "ERROR: Invalid command code";
-    static constexpr const char* INVALID_QUERY_CODE = "ERROR: Invalid query code";
-    static constexpr const char* UNKNOWN_COMMAND = "ERROR: Unknown command";
-    static constexpr const char* UNABLE_TO_PARSE_REQUEST_ERROR = "ERROR: Unable to parse request";
-    static constexpr const char* INVALID_COMMAND_FORMAT = "ERROR: Invalid command format";
 
-    static constexpr const char* GET_STR = "GET";
-    static constexpr const char* SET_STR = "SET";
-    static constexpr const char* DEL_STR = "DEL";
+    extern const char MULTI_STR[];
+    extern const char EXEC_STR[];
+    extern const char DISCARD_STR[];
+    extern const char QUEUED_STR[];
+    extern const char RESP_ERR_MULTI_NESTED[];
+    extern const char RESP_ERR_EXEC_NO_MULTI[];
+    extern const char RESP_ERR_DISCARD_NO_MULTI[];
+    extern const char RESP_ERR_EXEC_ABORTED[];
+    extern const char OK[];
+    extern const char NOTHING[];
+    extern const char KEY_NOT_EXISTS[];
+    extern const char INTERNAL_ERROR[];
+    extern const char INVALID_COMMAND_CODE[];
+    extern const char INVALID_QUERY_CODE[];
+    extern const char UNKNOWN_COMMAND[];
+    extern const char UNABLE_TO_PARSE_REQUEST_ERROR[];
+    extern const char INVALID_COMMAND_FORMAT[];
+
+    extern const char GET_STR[];
+    extern const char SET_STR[];
+    extern const char DEL_STR[];
     /// @brief Query codes, 0: Reserved, 1: GET
     enum QueryCode : uint_fast8_t {
         UnknownQuery = 0,

--- a/src/server/protocol.hpp
+++ b/src/server/protocol.hpp
@@ -14,11 +14,13 @@ namespace server {
     inline constexpr char RESP_ARRAY_PREFIX = '*';
     inline constexpr char RESP_SIMPLE_PREFIX = '+';
     inline constexpr char RESP_BULK_PREFIX = '$';
+    inline constexpr char RESP_INTEGER_PREFIX = ':';
     inline constexpr char RESP_CR = '\r';
     inline constexpr char RESP_LF = '\n';
     inline constexpr char RESP_ERROR_PREFIX[] = "-ERR ";
     inline constexpr char RESP_NULL_BULK[] = "$-1\r\n";
     static constexpr const char* OK = "OK";
+    static constexpr const char* QUEUED = "QUEUED";
     static constexpr const char* NOTHING = "(nil)";
     static constexpr const char* KEY_NOT_EXISTS = "ERROR: Key does not exist";
     static constexpr const char* INTERNAL_ERROR = "ERROR: Internal error";
@@ -31,6 +33,9 @@ namespace server {
     static constexpr const char* GET_STR = "GET";
     static constexpr const char* SET_STR = "SET";
     static constexpr const char* DEL_STR = "DEL";
+    static constexpr const char* MULTI_STR = "MULTI";
+    static constexpr const char* EXEC_STR = "EXEC";
+    static constexpr const char* DISCARD_STR = "DISCARD";
 
     /// @brief Query codes, 0: Reserved, 1: GET
     enum QueryCode : uint_fast8_t {
@@ -91,7 +96,9 @@ namespace server {
 
     ResponsePacket makeCustomResponse(const char* message);
     ResponsePacket makeRespSimpleString(const char* message);
+    ResponsePacket makeRespInteger(int64_t value);
     ResponsePacket makeRespBulkString(const char* value);
+    ResponsePacket makeRespArray(const std::vector<ResponsePacket>& elements);
     ResponsePacket makeRespError(const char* message);
     ResponsePacket makeErrorResponse(RequestProtocol protocol, const char* message);
 }

--- a/src/server/protocol.hpp
+++ b/src/server/protocol.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstdint>
+#include <cstddef>
 #include <cctype>
 #include <charconv>
 #include <cstring>

--- a/src/server/protocol.hpp
+++ b/src/server/protocol.hpp
@@ -16,8 +16,8 @@ namespace server {
     inline constexpr char RESP_BULK_PREFIX = '$';
     inline constexpr char RESP_CR = '\r';
     inline constexpr char RESP_LF = '\n';
-    inline constexpr const char* RESP_ERROR_PREFIX = "-ERR ";
-    inline constexpr const char* RESP_NULL_BULK = "$-1\r\n";
+    inline constexpr char RESP_ERROR_PREFIX[] = "-ERR ";
+    inline constexpr char RESP_NULL_BULK[] = "$-1\r\n";
     static constexpr const char* OK = "OK";
     static constexpr const char* NOTHING = "(nil)";
     static constexpr const char* KEY_NOT_EXISTS = "ERROR: Key does not exist";

--- a/src/server/protocol.hpp
+++ b/src/server/protocol.hpp
@@ -10,6 +10,13 @@
 namespace server {
 
     static const char MSG_SEPARATOR = 0x1F;
+    inline constexpr char RESP_ARRAY_PREFIX = '*';
+    inline constexpr char RESP_SIMPLE_PREFIX = '+';
+    inline constexpr char RESP_BULK_PREFIX = '$';
+    inline constexpr char RESP_CR = '\r';
+    inline constexpr char RESP_LF = '\n';
+    inline constexpr const char* RESP_ERROR_PREFIX = "-ERR ";
+    inline constexpr const char* RESP_NULL_BULK = "$-1\r\n";
     static constexpr const char* OK = "OK";
     static constexpr const char* NOTHING = "(nil)";
     static constexpr const char* KEY_NOT_EXISTS = "ERROR: Key does not exist";

--- a/src/server/protocol.hpp
+++ b/src/server/protocol.hpp
@@ -9,6 +9,8 @@
 #include <vector>
 #include <utility>
 #include <limits>
+#include <array>
+#include <atomic>
 
 namespace server {
 

--- a/src/server/protocol_test.cpp
+++ b/src/server/protocol_test.cpp
@@ -1,0 +1,99 @@
+#include <gtest/gtest.h>
+#include <vector>
+#include <string>
+#include <cstring>
+#include "protocol.hpp"
+
+using namespace server;
+
+TEST(RespProtocolTest, ParseRespMessageLengthComplete)
+{
+    const char request[] = "*2\r\n$3\r\nGET\r\n$3\r\nfoo\r\n";
+    std::vector<char> buffer(request, request + sizeof(request) - 1);
+    auto result = parseRespMessageLength(buffer, 0);
+    ASSERT_EQ(result.status, RespParseStatus::Complete);
+    ASSERT_EQ(result.length, sizeof(request) - 1);
+}
+
+TEST(RespProtocolTest, ParseRespMessageLengthIncomplete)
+{
+    const char partial[] = "*2\r\n$3\r\nGET\r\n$3\r\nfoo";
+    std::vector<char> buffer(partial, partial + sizeof(partial) - 1);
+    auto result = parseRespMessageLength(buffer, 0);
+    ASSERT_EQ(result.status, RespParseStatus::Incomplete);
+}
+
+TEST(RespProtocolTest, ParseRespCommandGet)
+{
+    std::string payload = "*2\r\n$3\r\nGET\r\n$3\r\nbar\r\n";
+    RespCommandParts parts{};
+    ASSERT_TRUE(parseRespCommand(payload, parts));
+    ASSERT_EQ(parts.argc, 2u);
+    ASSERT_STREQ(parts.command, GET_STR);
+    ASSERT_STREQ(parts.key, "bar");
+    ASSERT_EQ(parts.value, nullptr);
+}
+
+TEST(RespProtocolTest, ParseRespCommandSet)
+{
+    std::string payload = "*3\r\n$3\r\nSET\r\n$3\r\nkey\r\n$5\r\nvalue\r\n";
+    RespCommandParts parts{};
+    ASSERT_TRUE(parseRespCommand(payload, parts));
+    ASSERT_EQ(parts.argc, 3u);
+    ASSERT_STREQ(parts.command, SET_STR);
+    ASSERT_STREQ(parts.key, "key");
+    ASSERT_STREQ(parts.value, "value");
+}
+
+TEST(RespProtocolTest, MakeRespSimpleString)
+{
+    auto response = makeRespSimpleString(OK);
+    ASSERT_EQ(response.protocol, RequestProtocol::RESP);
+    ASSERT_EQ(response.size, 5u);
+    ASSERT_NE(response.owned, nullptr);
+    std::string serialized(response.data, response.size);
+    ASSERT_EQ(serialized, "+OK\r\n");
+}
+
+TEST(RespProtocolTest, MakeRespBulkString)
+{
+    auto response = makeRespBulkString("hello");
+    ASSERT_EQ(response.protocol, RequestProtocol::RESP);
+    ASSERT_EQ(response.size, 11u);
+    ASSERT_NE(response.owned, nullptr);
+    std::string serialized(response.data, response.size);
+    ASSERT_EQ(serialized, "$5\r\nhello\r\n");
+}
+
+TEST(RespProtocolTest, MakeRespNullBulkString)
+{
+    auto response = makeRespBulkString(NOTHING);
+    ASSERT_EQ(response.protocol, RequestProtocol::RESP);
+    ASSERT_EQ(response.size, 5u);
+    ASSERT_EQ(response.owned, nullptr);
+    std::string serialized(response.data, response.size);
+    ASSERT_EQ(serialized, "$-1\r\n");
+}
+
+TEST(RespProtocolTest, ErrorResponseMatchesProtocol)
+{
+    auto customError = makeErrorResponse(RequestProtocol::Custom, UNKNOWN_COMMAND);
+    ASSERT_EQ(customError.protocol, RequestProtocol::Custom);
+    ASSERT_EQ(customError.size, std::strlen(UNKNOWN_COMMAND));
+    ASSERT_EQ(customError.owned, nullptr);
+
+    auto respError = makeErrorResponse(RequestProtocol::RESP, UNKNOWN_COMMAND);
+    ASSERT_EQ(respError.protocol, RequestProtocol::RESP);
+    ASSERT_NE(respError.owned, nullptr);
+    std::string serialized(respError.data, respError.size);
+    ASSERT_EQ(serialized, "-ERR ERROR: Unknown command\r\n");
+}
+
+TEST(CustomProtocolTest, MakeCustomResponse)
+{
+    auto response = makeCustomResponse(OK);
+    ASSERT_EQ(response.protocol, RequestProtocol::Custom);
+    ASSERT_EQ(response.data, OK);
+    ASSERT_EQ(response.size, std::strlen(OK));
+    ASSERT_EQ(response.owned, nullptr);
+}

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -328,7 +328,7 @@ AsyncReadTask server::CacheServer::readRequestAsync(int client_fd)
             continue;
         }
 
-        if (current == '*') {
+        if (current == RESP_ARRAY_PREFIX) {
             auto parseResult = parseRespMessageLength(connData.readBuffer, start);
             if (parseResult.status == RespParseStatus::Incomplete) {
                 break;
@@ -336,6 +336,9 @@ AsyncReadTask server::CacheServer::readRequestAsync(int client_fd)
 
             if (parseResult.status == RespParseStatus::Error) {
                 ++numErrors;
+                connData.pendingRequests.clear();
+                connData.readBuffer.clear();
+                connData.bytesToErase = 0;
                 co_return ReadRequestResult{ ReqReadOperationResult::Failure };
             }
 

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -366,8 +366,7 @@ HandleReqTask CacheServer::handleRequests()
 #endif
                 auto readResult = co_await readers[i];
                 if (readResult.operationResult == ReqReadOperationResult::Failure) {
-
-                    //TODO: add special handling?
+                    connManager->closeConnection(fd);
                     continue;
                 }
 
@@ -427,7 +426,6 @@ AsyncReadTask server::CacheServer::readRequestAsync(int client_fd)
         }
 
         if (bytes_read == 0) {
-            connManager->closeConnection(client_fd);
             co_return ReadRequestResult{ ReqReadOperationResult::Failure };
         }
 
@@ -455,7 +453,6 @@ AsyncReadTask server::CacheServer::readRequestAsync(int client_fd)
                 connData.pendingRequests.clear();
                 connData.readBuffer.clear();
                 connData.bytesToErase = 0;
-                connManager->closeConnection(client_fd);
                 co_return ReadRequestResult{ ReqReadOperationResult::Failure };
             }
 

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -1,10 +1,16 @@
 #include "server.hpp"
 #include <unordered_map>
+#include <string>
+#include <vector>
 
 using namespace server;
 
+ConnectionData::~ConnectionData() = default;
+
 CacheServer::CacheServer(const ServerSettings settings): numShards(settings.numShards), port(settings.port)
 {
+    setRespInlineCapacity(settings.respInlineCapacity);
+
     server_fd = socket(AF_INET, SOCK_STREAM, 0);
     if (server_fd == -1) {
         throw std::system_error(errno, std::system_category(), "Socket creation failed");
@@ -102,7 +108,7 @@ ProcessRequestTask server::CacheServer::processRequest(const RequestView& reques
 
 ResponsePacket CacheServer::processRequestSync(const RequestView& request, ConnectionData& connData)
 {
-    auto handleGet = [&](char* keyPtr, RequestProtocol protocol) -> ResponsePacket {
+    auto handleGet = [&](const char* keyPtr, RequestProtocol protocol) -> ResponsePacket {
         auto hash = hashFunc(keyPtr);
         auto& shard = serverShards[hash % numShards];
         Query query{QueryCode::GET, keyPtr, hash};
@@ -110,7 +116,7 @@ ResponsePacket CacheServer::processRequestSync(const RequestView& request, Conne
         return protocol == RequestProtocol::RESP ? makeRespBulkString(result) : makeCustomResponse(result);
     };
 
-    auto handleSet = [&](char* keyPtr, const char* valuePtr, RequestProtocol protocol) -> ResponsePacket {
+    auto handleSet = [&](const char* keyPtr, const char* valuePtr, RequestProtocol protocol) -> ResponsePacket {
         auto hash = hashFunc(keyPtr);
         auto& shard = serverShards[hash % numShards];
         Command cmd{CommandCode::SET, keyPtr, valuePtr, hash};
@@ -121,7 +127,7 @@ ResponsePacket CacheServer::processRequestSync(const RequestView& request, Conne
         return makeCustomResponse(result);
     };
 
-    auto handleDel = [&](char* keyPtr, RequestProtocol protocol) -> ResponsePacket {
+    auto handleDel = [&](const char* keyPtr, RequestProtocol protocol) -> ResponsePacket {
         auto hash = hashFunc(keyPtr);
         auto& shard = serverShards[hash % numShards];
         Command cmd{CommandCode::DEL, keyPtr, nullptr, hash};
@@ -139,84 +145,137 @@ ResponsePacket CacheServer::processRequestSync(const RequestView& request, Conne
     };
 
     if (request.protocol == RequestProtocol::RESP) {
+        auto markRespTransactionError = [&]() {
+            if (connData.respTransaction && connData.respTransaction->active) {
+                connData.respTransaction->aborted = true;
+            }
+        };
+
+        auto ensureRespTransaction = [&]() -> RespTransactionState& {
+            if (!connData.respTransaction) {
+                connData.respTransaction = std::make_unique<RespTransactionState>();
+            }
+            return *connData.respTransaction;
+        };
+
+        auto queueRespCommand = [&](RespTransactionState::CommandType type, const char* key, const char* value) -> ResponsePacket {
+            auto& tx = ensureRespTransaction();
+            if (!tx.active) {
+                ++numErrors;
+                return makeRespError(RESP_ERR_EXEC_NO_MULTI);
+            }
+            tx.queue.emplace_back();
+            auto& queued = tx.queue.back();
+            queued.type = type;
+            queued.key = tx.persistString(key);
+            queued.value = tx.persistString(value);
+            return makeRespSimpleString(QUEUED_STR);
+        };
+
         RespCommandParts parts{};
         if (!parseRespCommand(request.payload, parts)) {
             ++numErrors;
+            markRespTransactionError();
             return makeErrorResponse(RequestProtocol::RESP, UNABLE_TO_PARSE_REQUEST_ERROR);
         }
 
-        auto queueOrReturn = [&](ResponsePacket&& response) -> ResponsePacket {
-            if (connData.inTransaction) {
-                connData.transactionQueue.push_back(std::move(response));
-                return makeRespSimpleString(QUEUED);
-            }
-            return std::move(response);
-        };
-
         if (std::strcmp(parts.command, MULTI_STR) == 0) {
-            if (parts.argc != 1) {
+            auto& tx = ensureRespTransaction();
+            if (tx.active) {
                 ++numErrors;
-                return makeErrorResponse(RequestProtocol::RESP, INVALID_COMMAND_FORMAT);
+                markRespTransactionError();
+                return makeRespError(RESP_ERR_MULTI_NESTED);
             }
-            connData.inTransaction = true;
-            connData.transactionQueue.clear();
+            tx.active = true;
+            tx.aborted = false;
+            tx.clearQueue();
             return makeRespSimpleString(OK);
         }
 
         if (std::strcmp(parts.command, DISCARD_STR) == 0) {
-            if (parts.argc != 1) {
+            if (!connData.respTransaction || !connData.respTransaction->active) {
                 ++numErrors;
-                return makeErrorResponse(RequestProtocol::RESP, INVALID_COMMAND_FORMAT);
+                return makeRespError(RESP_ERR_DISCARD_NO_MULTI);
             }
-            if (!connData.inTransaction) {
-                ++numErrors;
-                return makeRespError("DISCARD without MULTI");
-            }
-            connData.inTransaction = false;
-            connData.transactionQueue.clear();
+            auto& tx = *connData.respTransaction;
+            tx.clearQueue();
+            tx.active = false;
+            tx.aborted = false;
             return makeRespSimpleString(OK);
         }
 
         if (std::strcmp(parts.command, EXEC_STR) == 0) {
-            if (parts.argc != 1) {
+            if (!connData.respTransaction || !connData.respTransaction->active) {
                 ++numErrors;
-                return makeErrorResponse(RequestProtocol::RESP, INVALID_COMMAND_FORMAT);
+                return makeRespError(RESP_ERR_EXEC_NO_MULTI);
             }
-            if (!connData.inTransaction) {
+            auto& tx = *connData.respTransaction;
+            if (tx.aborted) {
+                tx.clearQueue();
+                tx.active = false;
+                tx.aborted = false;
                 ++numErrors;
-                return makeRespError("EXEC without MULTI");
+                return makeRespError(RESP_ERR_EXEC_ABORTED);
             }
-            auto response = makeRespArray(connData.transactionQueue);
-            connData.transactionQueue.clear();
-            connData.inTransaction = false;
-            return response;
+            std::vector<ResponsePacket> results;
+            results.reserve(tx.queue.size());
+            for (auto& queued : tx.queue) {
+                switch (queued.type) {
+                    case RespTransactionState::CommandType::Get:
+                        results.emplace_back(handleGet(queued.key, RequestProtocol::RESP));
+                        break;
+                    case RespTransactionState::CommandType::Set:
+                        results.emplace_back(handleSet(queued.key, queued.value, RequestProtocol::RESP));
+                        break;
+                    case RespTransactionState::CommandType::Del:
+                        results.emplace_back(handleDel(queued.key, RequestProtocol::RESP));
+                        break;
+                }
+            }
+            tx.clearQueue();
+            tx.active = false;
+            tx.aborted = false;
+            return makeRespArray(results);
         }
 
         if (std::strcmp(parts.command, GET_STR) == 0) {
             if (parts.argc != 2) {
                 ++numErrors;
+                markRespTransactionError();
                 return makeErrorResponse(RequestProtocol::RESP, INVALID_COMMAND_FORMAT);
             }
-            return queueOrReturn(handleGet(parts.key, RequestProtocol::RESP));
+            if (connData.respTransaction && connData.respTransaction->active) {
+                return queueRespCommand(RespTransactionState::CommandType::Get, parts.key, nullptr);
+            }
+            return handleGet(parts.key, RequestProtocol::RESP);
         }
 
         if (std::strcmp(parts.command, SET_STR) == 0) {
             if (parts.argc != 3 || parts.value == nullptr) {
                 ++numErrors;
+                markRespTransactionError();
                 return makeErrorResponse(RequestProtocol::RESP, INVALID_COMMAND_FORMAT);
             }
-            return queueOrReturn(handleSet(parts.key, parts.value, RequestProtocol::RESP));
+            if (connData.respTransaction && connData.respTransaction->active) {
+                return queueRespCommand(RespTransactionState::CommandType::Set, parts.key, parts.value);
+            }
+            return handleSet(parts.key, parts.value, RequestProtocol::RESP);
         }
 
         if (std::strcmp(parts.command, DEL_STR) == 0) {
             if (parts.argc != 2) {
                 ++numErrors;
+                markRespTransactionError();
                 return makeErrorResponse(RequestProtocol::RESP, INVALID_COMMAND_FORMAT);
             }
-            return queueOrReturn(handleDel(parts.key, RequestProtocol::RESP));
+            if (connData.respTransaction && connData.respTransaction->active) {
+                return queueRespCommand(RespTransactionState::CommandType::Del, parts.key, nullptr);
+            }
+            return handleDel(parts.key, RequestProtocol::RESP);
         }
 
         ++numErrors;
+        markRespTransactionError();
         return makeErrorResponse(RequestProtocol::RESP, UNKNOWN_COMMAND);
     }
 

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -366,6 +366,7 @@ HandleReqTask CacheServer::handleRequests()
 #endif
                 auto readResult = co_await readers[i];
                 if (readResult.operationResult == ReqReadOperationResult::Failure) {
+
                     //TODO: add special handling?
                     continue;
                 }
@@ -454,6 +455,7 @@ AsyncReadTask server::CacheServer::readRequestAsync(int client_fd)
                 connData.pendingRequests.clear();
                 connData.readBuffer.clear();
                 connData.bytesToErase = 0;
+                connManager->closeConnection(client_fd);
                 co_return ReadRequestResult{ ReqReadOperationResult::Failure };
             }
 

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -122,7 +122,7 @@ ResponsePacket CacheServer::processRequestSync(const RequestView& request, Conne
         Command cmd{CommandCode::SET, keyPtr, valuePtr, hash};
         const char* result = shard.processCommand(cmd);
         if (protocol == RequestProtocol::RESP) {
-            return result == OK ? makeRespSimpleString(result) : makeRespError(result);
+            return (result && std::strcmp(result, OK) == 0) ? makeRespSimpleString(result) : makeRespError(result);
         }
         return makeCustomResponse(result);
     };
@@ -133,10 +133,10 @@ ResponsePacket CacheServer::processRequestSync(const RequestView& request, Conne
         Command cmd{CommandCode::DEL, keyPtr, nullptr, hash};
         const char* result = shard.processCommand(cmd);
         if (protocol == RequestProtocol::RESP) {
-            if (result == OK) {
+            if (result && std::strcmp(result, OK) == 0) {
                 return makeRespInteger(1);
             }
-            if (result == KEY_NOT_EXISTS) {
+            if (result && std::strcmp(result, KEY_NOT_EXISTS) == 0) {
                 return makeRespInteger(0);
             }
             return makeRespError(result);

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -91,12 +91,16 @@ CacheServer::~CacheServer() {
 
 ProcessRequestTask server::CacheServer::processRequest(const RequestView& request, int client_fd)
 {
-    auto response = processRequestSync(request);
+    auto connIt = connManager->connections.find(client_fd);
+    if (connIt == connManager->connections.end()) {
+        co_return;
+    }
+    auto response = processRequestSync(request, connIt->second);
     auto sendTask = sendResponse(client_fd, response);
     co_await sendTask;
 }
 
-ResponsePacket CacheServer::processRequestSync(const RequestView& request)
+ResponsePacket CacheServer::processRequestSync(const RequestView& request, ConnectionData& connData)
 {
     auto handleGet = [&](char* keyPtr, RequestProtocol protocol) -> ResponsePacket {
         auto hash = hashFunc(keyPtr);
@@ -123,7 +127,13 @@ ResponsePacket CacheServer::processRequestSync(const RequestView& request)
         Command cmd{CommandCode::DEL, keyPtr, nullptr, hash};
         const char* result = shard.processCommand(cmd);
         if (protocol == RequestProtocol::RESP) {
-            return result == OK ? makeRespSimpleString(result) : makeRespError(result);
+            if (result == OK) {
+                return makeRespInteger(1);
+            }
+            if (result == KEY_NOT_EXISTS) {
+                return makeRespInteger(0);
+            }
+            return makeRespError(result);
         }
         return makeCustomResponse(result);
     };
@@ -135,12 +145,59 @@ ResponsePacket CacheServer::processRequestSync(const RequestView& request)
             return makeErrorResponse(RequestProtocol::RESP, UNABLE_TO_PARSE_REQUEST_ERROR);
         }
 
+        auto queueOrReturn = [&](ResponsePacket&& response) -> ResponsePacket {
+            if (connData.inTransaction) {
+                connData.transactionQueue.push_back(std::move(response));
+                return makeRespSimpleString(QUEUED);
+            }
+            return std::move(response);
+        };
+
+        if (std::strcmp(parts.command, MULTI_STR) == 0) {
+            if (parts.argc != 1) {
+                ++numErrors;
+                return makeErrorResponse(RequestProtocol::RESP, INVALID_COMMAND_FORMAT);
+            }
+            connData.inTransaction = true;
+            connData.transactionQueue.clear();
+            return makeRespSimpleString(OK);
+        }
+
+        if (std::strcmp(parts.command, DISCARD_STR) == 0) {
+            if (parts.argc != 1) {
+                ++numErrors;
+                return makeErrorResponse(RequestProtocol::RESP, INVALID_COMMAND_FORMAT);
+            }
+            if (!connData.inTransaction) {
+                ++numErrors;
+                return makeRespError("DISCARD without MULTI");
+            }
+            connData.inTransaction = false;
+            connData.transactionQueue.clear();
+            return makeRespSimpleString(OK);
+        }
+
+        if (std::strcmp(parts.command, EXEC_STR) == 0) {
+            if (parts.argc != 1) {
+                ++numErrors;
+                return makeErrorResponse(RequestProtocol::RESP, INVALID_COMMAND_FORMAT);
+            }
+            if (!connData.inTransaction) {
+                ++numErrors;
+                return makeRespError("EXEC without MULTI");
+            }
+            auto response = makeRespArray(connData.transactionQueue);
+            connData.transactionQueue.clear();
+            connData.inTransaction = false;
+            return response;
+        }
+
         if (std::strcmp(parts.command, GET_STR) == 0) {
             if (parts.argc != 2) {
                 ++numErrors;
                 return makeErrorResponse(RequestProtocol::RESP, INVALID_COMMAND_FORMAT);
             }
-            return handleGet(parts.key, RequestProtocol::RESP);
+            return queueOrReturn(handleGet(parts.key, RequestProtocol::RESP));
         }
 
         if (std::strcmp(parts.command, SET_STR) == 0) {
@@ -148,7 +205,7 @@ ResponsePacket CacheServer::processRequestSync(const RequestView& request)
                 ++numErrors;
                 return makeErrorResponse(RequestProtocol::RESP, INVALID_COMMAND_FORMAT);
             }
-            return handleSet(parts.key, parts.value, RequestProtocol::RESP);
+            return queueOrReturn(handleSet(parts.key, parts.value, RequestProtocol::RESP));
         }
 
         if (std::strcmp(parts.command, DEL_STR) == 0) {
@@ -156,7 +213,7 @@ ResponsePacket CacheServer::processRequestSync(const RequestView& request)
                 ++numErrors;
                 return makeErrorResponse(RequestProtocol::RESP, INVALID_COMMAND_FORMAT);
             }
-            return handleDel(parts.key, RequestProtocol::RESP);
+            return queueOrReturn(handleDel(parts.key, RequestProtocol::RESP));
         }
 
         ++numErrors;
@@ -264,7 +321,7 @@ HandleReqTask CacheServer::handleRequests()
                 while (!connData.pendingRequests.empty()) {
                     auto req = connData.pendingRequests.front();
                     connData.pendingRequests.pop_front();
-                    responses.emplace_back(processRequestSync(req));
+                    responses.emplace_back(processRequestSync(req, connData));
                 }
                 if (connData.bytesToErase > 0) {
                     connData.readBuffer.erase(connData.readBuffer.begin(), connData.readBuffer.begin() + connData.bytesToErase);

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -365,13 +365,8 @@ HandleReqTask CacheServer::handleRequests()
                 std::cout << "reading request from client_fd = " << fd  << ", epoll_fd = " << epoll_fd << std::endl;
 #endif
                 auto readResult = co_await readers[i];
-                if (readResult.operationResult == ReqReadOperationResult::Failure) {
 
-                    //TODO: add special handling?
-                    continue;
-                }
-
-                if (readResult.operationResult == ReqReadOperationResult::AwaitingData) {
+                if (readResult.operationResult == ReqReadOperationResult::Failure || readResult.operationResult == ReqReadOperationResult::AwaitingData) {
                     continue;
                 }
 

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -366,7 +366,8 @@ HandleReqTask CacheServer::handleRequests()
 #endif
                 auto readResult = co_await readers[i];
                 if (readResult.operationResult == ReqReadOperationResult::Failure) {
-                    connManager->closeConnection(fd);
+
+                    //TODO: add special handling?
                     continue;
                 }
 
@@ -426,6 +427,7 @@ AsyncReadTask server::CacheServer::readRequestAsync(int client_fd)
         }
 
         if (bytes_read == 0) {
+            connManager->closeConnection(client_fd);
             co_return ReadRequestResult{ ReqReadOperationResult::Failure };
         }
 
@@ -453,6 +455,7 @@ AsyncReadTask server::CacheServer::readRequestAsync(int client_fd)
                 connData.pendingRequests.clear();
                 connData.readBuffer.clear();
                 connData.bytesToErase = 0;
+                connManager->closeConnection(client_fd);
                 co_return ReadRequestResult{ ReqReadOperationResult::Failure };
             }
 

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -558,7 +558,7 @@ void CacheServer::sendResponses(int client_fd, const std::vector<ResponsePacket>
         if (response.protocol == RequestProtocol::Custom) {
             separators.push_back(MSG_SEPARATOR);
             iovec sepVec{};
-            sepVec.iov_base = reinterpret_cast<void*>(&separators.back());
+            sepVec.iov_base = static_cast<void*>(&separators.back());
             sepVec.iov_len = 1;
             iov.push_back(sepVec);
             totalRequired += 1;

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -492,6 +492,7 @@ AsyncReadTask server::CacheServer::readRequestAsync(int client_fd)
 
     co_return ReadRequestResult{ ReqReadOperationResult::AwaitingData };
 }
+
 AsyncSendTask CacheServer::sendResponse(int client_fd, const ResponsePacket& response) {
     char sep = MSG_SEPARATOR;
     struct iovec iov[2];

--- a/src/server/server.hpp
+++ b/src/server/server.hpp
@@ -59,6 +59,9 @@ namespace server {
 
         /// @brief Enable compression of stored values. Disable if RPS and processing speed is more important than memory consumption
         bool enableCompression = false;
+
+        /// @brief Inline RESP response capacity before falling back to heap allocations
+        std::size_t respInlineCapacity = 255;
     };
 
     class CacheServer : NonCopyableOrMovable {

--- a/src/server/server.hpp
+++ b/src/server/server.hpp
@@ -92,7 +92,7 @@ namespace server {
 
             AsyncReadTask readRequestAsync(int client_fd);
             ProcessRequestTask processRequest(const RequestView& request, int client_fd);
-            ResponsePacket processRequestSync(const RequestView& request);
+            ResponsePacket processRequestSync(const RequestView& request, ConnectionData& connData);
             HandleReqTask handleRequests();
             AsyncSendTask sendResponse(int client_fd, const ResponsePacket& response);
             void sendResponses(int client_fd, const std::vector<ResponsePacket>& responses);

--- a/src/server/server.hpp
+++ b/src/server/server.hpp
@@ -36,10 +36,39 @@ namespace server {
         uint_fast64_t numErrors = 0;
         uint_fast32_t numActiveConnections = 0;
         uint_fast64_t numRequests = 0;
-        uint_fast32_t eventsPerBatch = 0;
 
-        CacheServerMetrics(uint_fast64_t numErrors, uint_fast32_t numConnections, uint_fast64_t numRequests, uint_fast32_t eventsPerBatch):
-        numErrors(numErrors), numActiveConnections(numConnections), numRequests(numRequests), eventsPerBatch(eventsPerBatch) {}
+        CacheServerMetrics() = default;
+
+        CacheServerMetrics(uint_fast64_t numErrors, uint_fast32_t numConnections, uint_fast64_t numRequests):
+            numErrors(numErrors), numActiveConnections(numConnections), numRequests(numRequests) {}
+
+    };
+
+    class MetricsChannel {
+        public:
+            void push(const CacheServerMetrics& metrics) {
+                std::scoped_lock lock(mutex);
+                queue.push(metrics);
+            }
+
+            bool try_pop(CacheServerMetrics& metrics) {
+                std::scoped_lock lock(mutex);
+                if (queue.empty()) {
+                    return false;
+                }
+                metrics = queue.front();
+                queue.pop();
+                return true;
+            }
+
+            bool empty() const {
+                std::scoped_lock lock(mutex);
+                return queue.empty();
+            }
+
+        private:
+            mutable std::mutex mutex;
+            std::queue<CacheServerMetrics> queue;
     };
 
     struct ServerSettings {
@@ -80,7 +109,6 @@ namespace server {
             std::mutex req_handle_mutex;
             std::atomic<uint_fast64_t> numErrors = 0;
             std::atomic<uint_fast64_t> numRequests = 0;
-            std::atomic<uint_fast32_t> eventsPerBatch = 0;
             std::atomic<bool> isRunning = false;
             std::jthread metricsUpdaterThread;
             std::jthread connManagerThread;
@@ -99,7 +127,7 @@ namespace server {
             HandleReqTask handleRequests();
             AsyncSendTask sendResponse(int client_fd, const ResponsePacket& response);
             void sendResponses(int client_fd, const std::vector<ResponsePacket>& responses);
-            void metricsUpdater(std::queue<CacheServerMetrics>& channel, std::stop_token stopToken);
+            void metricsUpdater(MetricsChannel& channel, std::stop_token stopToken);
         public:
             CacheServer(const ServerSettings settings = ServerSettings{});
             ~CacheServer();
@@ -107,7 +135,7 @@ namespace server {
             /// @brief Starts processing incoming requests
             /// @param channel metrics queue to report to
             /// @return operation result, 0 - success, other values - failure
-            int Start(std::queue<CacheServerMetrics>& channel);
+            int Start(MetricsChannel& channel);
 
             /// @brief Gracefully stops server, restart is not (yet) supported
             void Stop() noexcept;

--- a/src/server/server.hpp
+++ b/src/server/server.hpp
@@ -91,11 +91,11 @@ namespace server {
             epoll_event epoll_events[MAX_EVENTS];
 
             AsyncReadTask readRequestAsync(int client_fd);
-            ProcessRequestTask processRequest(std::string_view requestData, int client_fd);
-            const char* processRequestSync(std::string_view requestData);
+            ProcessRequestTask processRequest(const RequestView& request, int client_fd);
+            ResponsePacket processRequestSync(const RequestView& request);
             HandleReqTask handleRequests();
-            AsyncSendTask sendResponse(int client_fd, const char* response);
-            void sendResponses(int client_fd, const std::vector<const char*>& responses);
+            AsyncSendTask sendResponse(int client_fd, const ResponsePacket& response);
+            void sendResponses(int client_fd, const std::vector<ResponsePacket>& responses);
             void metricsUpdater(std::queue<CacheServerMetrics>& channel, std::stop_token stopToken);
         public:
             CacheServer(const ServerSettings settings = ServerSettings{});

--- a/tests/client_integration/client_integration_test.cpp
+++ b/tests/client_integration/client_integration_test.cpp
@@ -123,6 +123,6 @@ int main() {
         expect(finalGet.notFound(), "Key should be missing after deletion");
     }
 
-    std::cout << "Client integration test completed successfully" << std::endl;
+    std::cout << "Client integration test completed successfully\n";
     return EXIT_SUCCESS;
 }

--- a/tests/per_request_connection_test.py
+++ b/tests/per_request_connection_test.py
@@ -69,7 +69,7 @@ def send_command_to_custom_cache(command: str, bufSize: int):
                         break
                 except socket.timeout:
                     logger.error("Socket read timeout")
-                    exit(1)
+                    sys.exit(1)
                     return ""
                 except socket.error as e:
                     logger.error(e)
@@ -150,7 +150,7 @@ def preload_json_files():
             expectedResponse = "+OK" if cache_type == 'redis' else "OK"
             if response != expectedResponse:
                 logger.error(f"Failed to store {key} in cache. Response: {response}")
-                exit(1)
+                sys.exit(1)
             
             logger.info(f"Successfully stored {key} in cache.")
             time.sleep(delay_sec)
@@ -167,16 +167,16 @@ def preload_json_files():
                 if isBigData:
                     if len(response) != requestSize:
                         logger.error(f"Failed to retrieve {key} from cache! requestSize:{requestSize}, len(response): {len(response)}")
-                        exit(1)
+                        sys.exit(1)
                 else:
                     if response != json_content:
                         logger.error(f"Failed to retrieve {key} from cache! Response: {response}")
-                        exit(1)
+                        sys.exit(1)
             
             logger.info(f"Successfully retrieved {key} from cache.")
         except Exception as e:
             logger.error(f"Error processing {file_name}: {e}")
-            exit(1)
+            sys.exit(1)
 
 def test_iteration(x):
     """Perform one test iteration with SET and GET commands using retry logic."""
@@ -217,8 +217,8 @@ if __name__ == "__main__":
     time.sleep(delay_sec)
     load_test_res = run_load_tests()
     if load_test_res != 0:
-        exit(load_test_res)
+        sys.exit(load_test_res)
     logger.info(f"Deleting everything by sending DEL commands after {delay_sec} seconds...\n")
     time.sleep(delay_sec)
     del_res = delete_everything()
-    exit(del_res)
+    sys.exit(del_res)


### PR DESCRIPTION
## Summary
- add unit tests covering RESP parsing, command dispatch helpers, and custom protocol responses
- integrate the new protocol test binary into run-all-tests.bash so both wire formats are exercised during CI

## Testing
- `bash run-all-tests.bash`


------
https://chatgpt.com/codex/tasks/task_e_68edef30fac48333a4104ae0b17f040e