### PR TITLE
Auto-import Grafana dashboard, set Mimir single-node replication, add cluster controller and in-process metrics

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,29 +45,6 @@ jobs:
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 140
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 140
 
-      - name: Fetch prometheus-cpp dependency
-        if: matrix.language == 'cpp'
-        run: |
-          if [ ! -d prometheus-cpp ]; then
-            git clone --depth 1 https://github.com/jupp0r/prometheus-cpp.git prometheus-cpp
-          fi
-          git -C prometheus-cpp submodule update --init --recursive
-
-      - name: Build prometheus-cpp dependency
-        if: matrix.language == 'cpp'
-        env:
-          CC: gcc-14
-          CXX: g++-14
-        run: |
-          cmake -S prometheus-cpp -B prometheus-cpp/_build -G Ninja \
-            -DBUILD_SHARED_LIBS=ON \
-            -DENABLE_TESTING=OFF \
-            -DENABLE_PUSH=OFF \
-            -DENABLE_COMPRESSION=OFF \
-            -DENABLE_LOGGING=OFF
-          cmake --build prometheus-cpp/_build --parallel
-          cmake --install prometheus-cpp/_build --prefix "${{ github.workspace }}/prometheus-cpp/_install"
-
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
@@ -82,8 +59,6 @@ jobs:
 
       - name: Configure project
         if: matrix.language == 'cpp'
-        env:
-          CMAKE_PREFIX_PATH: "${{ github.workspace }}/prometheus-cpp/_install"
         run: |
           cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - name: Install dependencies and build prometheus-cpp
+    - name: Install native dependencies
       run: |
         set -e
         cd "$GITHUB_WORKSPACE"
@@ -84,19 +84,6 @@ jobs:
         sudo bash ./scripts/local_server_setup.bash
         sudo apt update && sudo apt upgrade -y
         sudo apt install -y git cmake build-essential libgtest-dev zlib1g-dev gcc-14 g++-14
-
-        if [ ! -d prometheus-cpp/.git ]; then
-          rm -rf prometheus-cpp
-          git clone https://github.com/jupp0r/prometheus-cpp.git
-        fi
-
-        cd prometheus-cpp && \
-        git submodule init && git submodule update && \
-        mkdir -p _build && cd _build && \
-        cmake .. -DBUILD_SHARED_LIBS=ON -DENABLE_PUSH=OFF -DENABLE_COMPRESSION=OFF && \
-        cmake --build . --parallel $(nproc) && \
-        ctest -V && \
-        sudo cmake --install .
 
         cd "$GITHUB_WORKSPACE"
         go install go.k6.io/xk6/cmd/xk6@latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,11 +22,6 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU
     endif ()
 endif ()
 
-find_package(prometheus-cpp CONFIG REQUIRED)
 find_package(ZLIB REQUIRED)
-
-if(NOT DEFINED prometheus-cpp_VERSION)
-  message(FATAL_ERROR "prometheus-cpp_VERSION is not defined")
-endif()
 
 add_subdirectory(src)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,5 @@
 FROM alpine:latest AS build
 RUN apk update && apk upgrade && apk add git cmake build-base gtest-dev zlib-dev bash go
-RUN git clone https://github.com/jupp0r/prometheus-cpp.git && cd prometheus-cpp \
-    && git submodule init && git submodule update && mkdir _build && cd _build \
-    && cmake .. -DBUILD_SHARED_LIBS=ON -DENABLE_PUSH=OFF -DENABLE_COMPRESSION=OFF \
-    && cmake --build . --parallel 4 \
-    && ctest -V \
-    && cmake --install .
 
 WORKDIR /app
 COPY . .
@@ -17,8 +11,8 @@ RUN bash /app/scripts/run-all-tests.bash
 
 ARG BUILD_TYPE="Release"
 RUN mkdir build && cd build && cmake .. -G"Unix Makefiles" -DCMAKE_BUILD_TYPE=$BUILD_TYPE && cd /app/build && cmake --build .
-# Build the launcher from within its module directory so Go can resolve go.mod
-RUN cd launcher && go build -o /app/pmc-cluster-launcher .
+# Build the cluster controller from within its module directory so Go can resolve go.mod
+RUN cd launcher && go build -o /app/pmc-cluster-controller .
 
 
 FROM alpine:latest
@@ -26,12 +20,11 @@ FROM alpine:latest
 RUN apk update && apk upgrade && apk add libstdc++ 
 
 COPY --from=build /app/build/src/poor-man-s-cache /app/poor-man-s-cache
-COPY --from=build /app/pmc-cluster-launcher /app/pmc-cluster-launcher
-COPY --from=build /usr/local/include/prometheus/ /usr/local/include/prometheus/
-COPY --from=build /usr/local/lib/ /usr/local/lib/
+COPY --from=build /app/pmc-cluster-controller /app/pmc-cluster-controller
 
 EXPOSE 9001
-EXPOSE 8080
+EXPOSE 9100
+EXPOSE 9400
 
 RUN addgroup -g 10001 notroot \
     && adduser -u 10001 -G notroot -h /app -s /sbin/nologin -D poor-man-s-cache

--- a/Dockerfile.callgrind
+++ b/Dockerfile.callgrind
@@ -1,11 +1,5 @@
 FROM alpine:latest AS build
 RUN apk update && apk upgrade && apk add git cmake build-base gtest-dev
-RUN git clone https://github.com/jupp0r/prometheus-cpp.git && cd prometheus-cpp \
-    && git submodule init && git submodule update && mkdir _build && cd _build \
-    && cmake .. -DBUILD_SHARED_LIBS=ON -DENABLE_PUSH=OFF -DENABLE_COMPRESSION=OFF \
-    && cmake --build . --parallel 4 \
-    && ctest -V \
-    && cmake --install .
 
 WORKDIR /app
 COPY . .
@@ -19,14 +13,12 @@ FROM alpine:latest
 RUN apk update && apk upgrade && apk add libstdc++ valgrind valgrind-scripts bash
 
 COPY --from=build /app/build/src/poor-man-s-cache /app/poor-man-s-cache
-COPY --from=build /usr/local/include/prometheus/ /usr/local/include/prometheus/
-COPY --from=build /usr/local/lib/ /usr/local/lib/
 
 WORKDIR /callgrind
 COPY ./scripts/callgrind.bash ./callgrind.bash
 
 EXPOSE 9001
-EXPOSE 8080
+EXPOSE 9100
 
 RUN addgroup -g 10001 notroot \
     && adduser -u 10001 -G notroot -h /app -s /sbin/nologin -D poor-man-s-cache

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,11 +1,5 @@
 FROM alpine:latest AS build
 RUN apk update && apk upgrade && apk add git cmake build-base gtest-dev zlib-dev bash
-RUN git clone https://github.com/jupp0r/prometheus-cpp.git && cd prometheus-cpp \
-    && git submodule init && git submodule update && mkdir _build && cd _build \
-    && cmake .. -DBUILD_SHARED_LIBS=ON -DENABLE_PUSH=OFF -DENABLE_COMPRESSION=OFF \
-    && cmake --build . --parallel 4 \
-    && ctest -V \
-    && cmake --install .
 
 WORKDIR /app
 COPY . .
@@ -24,11 +18,9 @@ FROM alpine:latest
 RUN apk update && apk upgrade && apk add libstdc++ valgrind bash
 COPY ./scripts/sockmon.bash /sockmon.bash
 COPY --from=build /app/build/src/poor-man-s-cache /app/poor-man-s-cache
-COPY --from=build /usr/local/include/prometheus/ /usr/local/include/prometheus/
-COPY --from=build /usr/local/lib/ /usr/local/lib/
 
 EXPOSE 9001
-EXPOSE 8080
+EXPOSE 9100
 
 RUN addgroup -g 10001 notroot \
     && adduser -u 10001 -G notroot -h /app -s /sbin/nologin -D poor-man-s-cache

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ To start a local 24-worker cluster:
 ```bash
 cmake --preset Release
 cmake --build ./out/build/Release
-go build -C ./launcher -o ../pmc-cluster-launcher
-./pmc-cluster-launcher ./out/build/Release/src/poor-man-s-cache 24 9001
+go build -C ./launcher -o ../pmc-cluster-controller
+./pmc-cluster-controller ./out/build/Release/src/poor-man-s-cache 24 9001
 ```
 
 > [!NOTE]
@@ -49,7 +49,7 @@ A lightweight three-step workflow is used in CI and can be mirrored locally:
 
 ```bash
 # 1) Start cluster (runs in background); adjust shard count/port as needed
-./pmc-cluster-launcher ./out/build/Release/src/poor-man-s-cache $CLUSTER_WORKERS $CACHE_PORT> cluster.log 2>&1 & echo $! > cluster.pid
+./pmc-cluster-controller ./out/build/Release/src/poor-man-s-cache $CLUSTER_WORKERS $CACHE_PORT> cluster.log 2>&1 & echo $! > cluster.pid
 
 # 2) Build and run cluster-aware tests (C++ client and python functional checks)
 g++ -std=c++20 -Wall -Wextra -Werror -pedantic -O2 -pthread -Isrc tests/client_integration/client_integration_test.cpp -o client_integration_test
@@ -109,8 +109,8 @@ Start the cluster:
 ```bash
 cmake --preset Release
 cmake --build ./out/build/Release
-go build -C ./launcher -o ../pmc-cluster-launcher
-./pmc-cluster-launcher ./out/build/Release/src/poor-man-s-cache 24 9001
+go build -C ./launcher -o ../pmc-cluster-controller
+./pmc-cluster-controller ./out/build/Release/src/poor-man-s-cache 24 9001
 ```
 
 Run tests from separate shell:
@@ -266,7 +266,22 @@ After the server has started, run the test script:
 docker compose -f docker-compose-local.yaml --profile tests up
 ```
 
-You can check Prometheus metrics while tests are running by opening http://localhost:8080/metrics
+You can check Prometheus metrics while tests are running by opening http://localhost:9100/metrics. Monitoring assets now live under `./observability` and are driven by Grafana Alloy.
+
+To launch the bundled Grafana stack with Grafana Alloy + Mimir (Prometheus-compatible backend) against containers in the same compose project, use `docker compose --profile main --profile cluster --profile monitoring up` and open Grafana at http://localhost:3000 with the pre-provisioned "Poor Man's Cache - Cluster" dashboard.
+
+For local development, you can run only Grafana Alloy + Mimir + Grafana in Docker while scraping a cache cluster running directly on localhost by overriding discovery and target addresses, for example:
+
+```bash
+PMC_PROM_TARGET_1=host.docker.internal:9100 \
+PMC_PROM_TARGET_2=host.docker.internal:9101 \
+PMC_PROM_DISCOVERY_URL=http://host.docker.internal:9400/discovery \
+PMC_GRAFANA_PROMETHEUS_URL=http://mimir:9009/prometheus \
+PMC_MIMIR_REMOTE_WRITE_URL=http://host.docker.internal:9009/api/v1/push \
+docker compose --profile monitoring up
+```
+
+The cluster controller discovery endpoint defaults to `http://cache-cluster:9400/discovery` and can still be adjusted via `PMC_DISCOVERY_ADDR` and `PMC_SCRAPE_HOST`; Grafana Alloy consumes it through HTTP service discovery so metrics targets are generated automatically from `CLUSTER_WORKERS` and the metrics base port.
 
 Don't forget to shut the detached container down by issuing:
 ```
@@ -290,14 +305,6 @@ Open second terminal somewhere on your hard drive and install required dependenc
 ```
 sudo apt update && sudo apt upgrade -y
 sudo apt install -y git cmake build-essential libgtest-dev zlib1g-dev gcc-14 g++-14
-
-git clone https://github.com/jupp0r/prometheus-cpp.git && cd prometheus-cpp && \
-git submodule init && git submodule update && \
-mkdir _build && cd _build && \
-cmake .. -DBUILD_SHARED_LIBS=ON -DENABLE_PUSH=OFF -DENABLE_COMPRESSION=OFF && \
-cmake --build . --parallel $(nproc) && \
-ctest -V && \
-sudo cmake --install .
 ```
 
 Set env variables, for example:
@@ -312,7 +319,7 @@ Run unit tests:
 
 ### Static analysis (CodeQL)
 
-The repository is scanned with GitHub CodeQL for C++, Python, and GitHub Actions sources. CodeQL analyses for Python and GitHub Actions run in `build-mode: none`, so no manual build steps are required for those languages. The C++ analysis path uses `build-mode: manual` to compile the project with GCC 14 and a locally installed copy of `prometheus-cpp`. To reproduce the same environment locally, use the following commands (they require sudo privileges):
+The repository is scanned with GitHub CodeQL for C++, Python, and GitHub Actions sources. CodeQL analyses for Python and GitHub Actions run in `build-mode: none`, so no manual build steps are required for those languages. The C++ analysis path uses `build-mode: manual` to compile the project with GCC 14. To reproduce the same environment locally, use the following commands (they require sudo privileges):
 
 ```bash
 sudo apt-get update
@@ -321,21 +328,7 @@ sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 sudo apt-get update
 sudo apt-get install -y gcc-14 g++-14 cmake ninja-build pkg-config zlib1g-dev libgtest-dev
 
-if [ ! -d prometheus-cpp ]; then
-  git clone https://github.com/jupp0r/prometheus-cpp.git prometheus-cpp
-fi
-git -C prometheus-cpp submodule update --init --recursive
-
-cmake -S prometheus-cpp -B prometheus-cpp/_build -G Ninja \
-  -DBUILD_SHARED_LIBS=ON \
-  -DENABLE_TESTING=OFF \
-  -DENABLE_PUSH=OFF \
-  -DENABLE_COMPRESSION=OFF \
-  -DENABLE_LOGGING=OFF
-cmake --build prometheus-cpp/_build --parallel
-cmake --install prometheus-cpp/_build --prefix "$(pwd)/prometheus-cpp/_install"
-
-CMAKE_PREFIX_PATH="$(pwd)/prometheus-cpp/_install" cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
 cmake --build build --config Release --parallel
 ```
 

--- a/common-compose-config.yaml
+++ b/common-compose-config.yaml
@@ -13,7 +13,8 @@ services:
         hard: "1048576"
     environment:
       - CACHE_PORT=9001
-      - METRICS_PORT=8080
+      - METRICS_PORT=9100
+      - METRICS_PORT_OFFSET=0
       - METRICS_HOST=0.0.0.0
       - NUM_SHARDS=128 # Higher number of shards increases memory overhead but usually leads to better RPS. Extremely high number of shards may lead to key collisions. Hard limit is 4,294,967,295
       - CONN_QUEUE_LIMIT=1048576 # Align with net.core.netdev_max_backlog = 1048576, net.core.somaxconn = 1048576 settings of kernel

--- a/docker-compose.yaml.j2
+++ b/docker-compose.yaml.j2
@@ -14,7 +14,7 @@ services:
       - cache_network
     ports:
       - "9001:9001"
-      - "8080:8080"
+      - "9100:9100"
 
   cache-cluster:
     build:
@@ -25,7 +25,7 @@ services:
     extends:
       file: common-compose-config.yaml
       service: cache-common
-    entrypoint: ["/app/pmc-cluster-launcher"]
+    entrypoint: ["/app/pmc-cluster-controller"]
     command: ["/app/poor-man-s-cache", "${CLUSTER_WORKERS:-8}", "${CLUSTER_BASE_PORT:-9001}"]
     environment:
       - CLUSTER_WORKERS=${CLUSTER_WORKERS:-8}
@@ -35,6 +35,62 @@ services:
     networks:
       - cache_network
     ports: []
+    expose:
+      - "9400"
+
+  mimir:
+    image: grafana/mimir:latest
+    profiles:
+      - monitoring
+    command:
+      - -config.file=/etc/mimir/mimir.yaml
+    volumes:
+      - ./observability/mimir/mimir.yaml:/etc/mimir/mimir.yaml:ro
+    ports:
+      - "9009:9009"
+    networks:
+      - cache_network
+
+  alloy:
+    image: grafana/alloy:latest
+    profiles:
+      - monitoring
+    environment:
+      - PMC_PROM_SCRAPE_INTERVAL=${PMC_PROM_SCRAPE_INTERVAL:-5s}
+      - PMC_PROM_SCRAPE_TIMEOUT=${PMC_PROM_SCRAPE_TIMEOUT:-5s}
+      - PMC_PROM_DISCOVERY_REFRESH_INTERVAL=${PMC_PROM_DISCOVERY_REFRESH_INTERVAL:-5s}
+      - PMC_PROM_TARGET_1=${PMC_PROM_TARGET_1:-cache:9100}
+      - PMC_PROM_TARGET_2=${PMC_PROM_TARGET_2:-host.docker.internal:9100}
+      - PMC_PROM_DISCOVERY_URL=${PMC_PROM_DISCOVERY_URL:-http://cache-cluster:9400/discovery}
+      - PMC_MIMIR_REMOTE_WRITE_URL=${PMC_MIMIR_REMOTE_WRITE_URL:-http://mimir:9009/api/v1/push}
+    command:
+      - run
+      - /etc/alloy/config.alloy
+    volumes:
+      - ./observability/alloy/config.alloy:/etc/alloy/config.alloy:ro
+    ports:
+      - "12345:12345"
+    depends_on:
+      - mimir
+    networks:
+      - cache_network
+
+  grafana:
+    image: grafana/grafana-oss:latest
+    profiles:
+      - monitoring
+    environment:
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      - PMC_GRAFANA_PROMETHEUS_URL=${PMC_GRAFANA_PROMETHEUS_URL:-http://mimir:9009/prometheus}
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./observability/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./observability/grafana:/var/lib/grafana/dashboards:ro
+    depends_on:
+      - mimir
+    networks:
+      - cache_network
 
 {% for i in range(1, num_tests + 1) %}
   tests-{{ i }}:

--- a/launcher/discovery_test.go
+++ b/launcher/discovery_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBuildTargetGroups(t *testing.T) {
+	cfg := Config{
+		WorkerCount:     3,
+		MetricsPortBase: 9100,
+		MetricsHost:     "cache-cluster",
+	}
+
+	groups := buildTargetGroups(cfg)
+	if len(groups) != 3 {
+		t.Fatalf("expected 3 groups, got %d", len(groups))
+	}
+
+	for i, g := range groups {
+		expectedTarget := fmt.Sprintf("cache-cluster:%d", 9100+i)
+		if len(g.Targets) != 1 || g.Targets[0] != expectedTarget {
+			t.Fatalf("unexpected target for shard %d: %+v", i, g.Targets)
+		}
+		if g.Labels["shard"] != fmt.Sprintf("%d", i) {
+			t.Fatalf("unexpected shard label: %v", g.Labels)
+		}
+	}
+}
+
+func TestResolveMetricsPortBase(t *testing.T) {
+	base := resolveMetricsPortBase(9100, 9101, 4)
+	if base != 9106 {
+		t.Fatalf("expected shifted metrics base to leave a gap, got %d", base)
+	}
+
+	unchanged := resolveMetricsPortBase(9200, 9101, 4)
+	if unchanged != 9200 {
+		t.Fatalf("expected metrics base to stay unchanged when non-overlapping, got %d", unchanged)
+	}
+}
+
+func TestDiscoveryHandler(t *testing.T) {
+	cfg := Config{
+		WorkerCount:       2,
+		MetricsPortBase:   9200,
+		MetricsHost:       "cache-cluster",
+		DiscoveryEndpoint: "/discovery",
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/discovery", nil)
+	discoveryHandler(cfg).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rr.Code)
+	}
+
+	var groups []targetGroup
+	if err := json.Unmarshal(rr.Body.Bytes(), &groups); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(groups) != 2 || groups[0].Targets[0] != "cache-cluster:9200" || groups[1].Targets[0] != "cache-cluster:9201" {
+		t.Fatalf("unexpected discovery payload: %+v", groups)
+	}
+}

--- a/launcher/go.mod
+++ b/launcher/go.mod
@@ -1,4 +1,4 @@
-module github.com/poor-man-s-cache/launcher
+module github.com/poor-man-s-cache/cluster-controller
 
 go 1.24.0
 

--- a/launcher/main.go
+++ b/launcher/main.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -17,10 +19,97 @@ import (
 )
 
 type Config struct {
-	WorkerCount int
-	BasePort    int
-	ServerPath  string
-	UseHugeTLB  bool
+	WorkerCount       int
+	BasePort          int
+	ServerPath        string
+	MetricsPortBase   int
+	MetricsHost       string
+	DiscoveryAddr     string
+	DiscoveryEndpoint string
+	UseHugeTLB        bool
+}
+
+func resolveMetricsPortBase(metricsBase, dataBase, workers int) int {
+	metricsRangeEnd := metricsBase + workers
+	dataRangeEnd := dataBase + workers
+	if metricsBase < dataRangeEnd && dataBase < metricsRangeEnd {
+		return dataRangeEnd + 1 // leave a closed port between data and metrics ranges
+	}
+	return metricsBase
+}
+
+func getEnvInt(key string, defaultVal int) int {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return defaultVal
+	}
+
+	v, err := strconv.Atoi(raw)
+	if err != nil {
+		log.Printf("invalid %s=%q; using %d", key, raw, defaultVal)
+		return defaultVal
+	}
+	return v
+}
+
+type targetGroup struct {
+	Targets []string          `json:"targets"`
+	Labels  map[string]string `json:"labels,omitempty"`
+}
+
+func buildTargetGroups(cfg Config) []targetGroup {
+	groups := make([]targetGroup, 0, cfg.WorkerCount)
+	for i := 0; i < cfg.WorkerCount; i++ {
+		port := cfg.MetricsPortBase + i
+		groups = append(groups, targetGroup{
+			Targets: []string{fmt.Sprintf("%s:%d", cfg.MetricsHost, port)},
+			Labels: map[string]string{
+				"shard": strconv.Itoa(i),
+				"node":  "local",
+			},
+		})
+	}
+	return groups
+}
+
+func discoveryHandler(cfg Config) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		groups := buildTargetGroups(cfg)
+		data, err := json.Marshal(groups)
+		if err != nil {
+			log.Printf("failed to marshal discovery targets: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(data)
+	})
+}
+
+func startDiscoveryServer(ctx context.Context, cfg Config) {
+	mux := http.NewServeMux()
+	mux.Handle(cfg.DiscoveryEndpoint, discoveryHandler(cfg))
+
+	srv := &http.Server{Addr: cfg.DiscoveryAddr, Handler: mux}
+
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
+	}()
+
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Printf("discovery server error: %v", err)
+		}
+	}()
 }
 
 func spawnWorkers(ctx context.Context, cfg Config) error {
@@ -86,6 +175,15 @@ func startWorkerOnce(ctx context.Context, cfg Config, i int) (*os.Process, error
 	cmd := exec.Command(cfg.ServerPath, "--listen", strconv.Itoa(port))
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+
+	metricsPort := cfg.MetricsPortBase + i
+
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("PMC_SHARD=%d", i),
+		fmt.Sprintf("PMC_NODE=%s", "local"),
+		fmt.Sprintf("METRICS_PORT=%d", metricsPort),
+		"METRICS_PORT_OFFSET=0",
+	)
 
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("worker %d start failed: %w", i, err)
@@ -212,27 +310,59 @@ func setRealtimePriority(pid int) error {
 
 func main() {
 	if len(os.Args) < 4 {
-		log.Fatal("Usage: launcher <server-binary> <worker-count> <base-port>")
+		log.Fatal("Usage: pmc-cluster-controller <server-binary> <worker-count> <base-port>")
 	}
 
 	workers, _ := strconv.Atoi(os.Args[2])
 	basePort, _ := strconv.Atoi(os.Args[3])
 
+	metricsPortBase := getEnvInt("METRICS_PORT", 9100)
+	metricsHost := os.Getenv("PMC_SCRAPE_HOST")
+	if metricsHost == "" {
+		metricsHost = "cache-cluster"
+	}
+
+	metricsPortBase = resolveMetricsPortBase(metricsPortBase, basePort, workers)
+	if metricsPortBase != getEnvInt("METRICS_PORT", 9100) {
+		log.Printf("metrics port base overlaps data ports; shifting to %d", metricsPortBase)
+	}
+
+	discoveryAddr := os.Getenv("PMC_DISCOVERY_ADDR")
+	if discoveryAddr == "" {
+		discoveryAddr = ":9400"
+	} else if !strings.Contains(discoveryAddr, ":") {
+		discoveryAddr = ":" + discoveryAddr
+	}
+
+	discoveryEndpoint := os.Getenv("PMC_DISCOVERY_ENDPOINT")
+	if discoveryEndpoint == "" {
+		discoveryEndpoint = "/discovery"
+	} else if !strings.HasPrefix(discoveryEndpoint, "/") {
+		discoveryEndpoint = "/" + discoveryEndpoint
+	}
+
 	cfg := Config{
-		ServerPath:  os.Args[1],
-		WorkerCount: workers,
-		BasePort:    basePort,
-		UseHugeTLB:  false,
+		ServerPath:        os.Args[1],
+		WorkerCount:       workers,
+		BasePort:          basePort,
+		MetricsPortBase:   metricsPortBase,
+		MetricsHost:       metricsHost,
+		DiscoveryAddr:     discoveryAddr,
+		DiscoveryEndpoint: discoveryEndpoint,
+		UseHugeTLB:        false,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+
+	startDiscoveryServer(ctx, cfg)
+	fmt.Printf("Discovery endpoint available at %s%s (metrics host=%s base=%d)\n", cfg.DiscoveryAddr, cfg.DiscoveryEndpoint, cfg.MetricsHost, cfg.MetricsPortBase)
 
 	sigs := make(chan os.Signal, 2)
 	signal.Notify(sigs, unix.SIGTERM, unix.SIGINT)
 
 	go func() {
 		sig := <-sigs
-		fmt.Fprintf(os.Stderr, "launcher received signal: %v — shutting down...\n", sig)
+		fmt.Fprintf(os.Stderr, "controller received signal: %v — shutting down...\n", sig)
 		cancel() // broadcast shutdown
 	}()
 

--- a/observability/alloy/config.alloy
+++ b/observability/alloy/config.alloy
@@ -1,0 +1,35 @@
+logging {
+  level = "info"
+}
+
+// Static targets (single node or local host overrides)
+prometheus.scrape "pmc_single" {
+  job_name = "pmc_single"
+  targets = [
+    { __address__ = env("PMC_PROM_TARGET_1") },
+    { __address__ = env("PMC_PROM_TARGET_2") },
+  ]
+  scrape_interval = env("PMC_PROM_SCRAPE_INTERVAL")
+  scrape_timeout = env("PMC_PROM_SCRAPE_TIMEOUT")
+  forward_to = [prometheus.remote_write.mimir.receiver]
+}
+
+// Cluster discovery targets
+discovery.http "pmc_cluster" {
+  url = env("PMC_PROM_DISCOVERY_URL")
+  refresh_interval = env("PMC_PROM_DISCOVERY_REFRESH_INTERVAL")
+}
+
+prometheus.scrape "pmc_cluster" {
+  job_name = "pmc_cluster"
+  targets = discovery.http.pmc_cluster.targets
+  scrape_interval = env("PMC_PROM_SCRAPE_INTERVAL")
+  scrape_timeout = env("PMC_PROM_SCRAPE_TIMEOUT")
+  forward_to = [prometheus.remote_write.mimir.receiver]
+}
+
+prometheus.remote_write "mimir" {
+  endpoint {
+    url = env("PMC_MIMIR_REMOTE_WRITE_URL")
+  }
+}

--- a/observability/grafana/pmc-cluster.json
+++ b/observability/grafana/pmc-cluster.json
@@ -1,0 +1,49 @@
+{
+  "title": "Poor Man's Cache - Cluster",
+  "uid": "pmc-cluster",
+  "schemaVersion": 38,
+  "version": 1,
+  "tags": ["pmc", "cache"],
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Request rate by operation",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0},
+      "targets": [
+        {"expr": "sum(rate(pmc_requests_total{op=\"get\"}[1m]))", "legendFormat": "get"},
+        {"expr": "sum(rate(pmc_requests_total{op=\"set\"}[1m]))", "legendFormat": "set"},
+        {"expr": "sum(rate(pmc_requests_total{op=\"del\"}[1m]))", "legendFormat": "del"},
+        {"expr": "sum(rate(pmc_requests_total{op=\"other\"}[1m]))", "legendFormat": "other"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Responses by status",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
+      "targets": [
+        {"expr": "sum(rate(pmc_responses_total{status=\"ok\"}[1m]))", "legendFormat": "ok"},
+        {"expr": "sum(rate(pmc_responses_total{status=\"not_found\"}[1m]))", "legendFormat": "not_found"},
+        {"expr": "sum(rate(pmc_responses_total{status=\"error\"}[1m]))", "legendFormat": "error"}
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Connections",
+      "gridPos": {"h": 6, "w": 6, "x": 0, "y": 8},
+      "targets": [
+        {"expr": "sum(pmc_connections_current)", "legendFormat": "current"},
+        {"expr": "sum(pmc_connections_accepted_total)", "legendFormat": "accepted"}
+      ],
+      "options": {"reduceOptions": {"calcs": ["last"]}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Bytes in/out",
+      "gridPos": {"h": 6, "w": 12, "x": 6, "y": 8},
+      "targets": [
+        {"expr": "sum(rate(pmc_bytes_rx_total[1m]))", "legendFormat": "rx"},
+        {"expr": "sum(rate(pmc_bytes_tx_total[1m]))", "legendFormat": "tx"}
+      ]
+    }
+  ]
+}

--- a/observability/grafana/provisioning/dashboards/dashboard.yaml
+++ b/observability/grafana/provisioning/dashboards/dashboard.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: 'pmc'
+    orgId: 1
+    folder: 'PMC'
+    type: file
+    disableDeletion: true
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/observability/grafana/provisioning/datasources/datasource.yaml
+++ b/observability/grafana/provisioning/datasources/datasource.yaml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: ${PMC_GRAFANA_PROMETHEUS_URL}
+    isDefault: true

--- a/observability/mimir/mimir.yaml
+++ b/observability/mimir/mimir.yaml
@@ -1,0 +1,28 @@
+multitenancy_enabled: false
+
+server:
+  http_listen_port: 9009
+
+common:
+  storage:
+    backend: filesystem
+    filesystem:
+      dir: /data
+
+blocks_storage:
+  storage_prefix: blocks
+  tsdb:
+    dir: /data/tsdb
+  bucket_store:
+    sync_dir: /data/tsdb-sync
+
+ingester:
+  ring:
+    replication_factor: 1
+    kvstore:
+      store: inmemory
+
+distributor:
+  ring:
+    kvstore:
+      store: inmemory

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,14 +16,6 @@ add_executable(
   compressor/gzip_compressor.cpp
 )
 
-if(PROMETHEUS_CPP_ENABLE_PUSH)
-  target_link_libraries(${PROJECT_NAME} PRIVATE prometheus-cpp::push $<$<BOOL:${WIN32}>:Ws2_32>)
-endif()
-
-if(PROMETHEUS_CPP_ENABLE_PULL)
-  target_link_libraries(${PROJECT_NAME} PRIVATE prometheus-cpp::pull)
-endif()
-
 target_link_libraries(${PROJECT_NAME} PRIVATE ZLIB::ZLIB)
 
 add_library(pmc_cache_client INTERFACE)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,10 +9,14 @@ using namespace server;
 
 int main(int argc, char* argv[]) {
     std::string cliListen;
+    std::string metricsListen;
     for (int i = 1; i + 1 < argc; ++i) {
         if (std::string_view(argv[i]) == "--listen") {
             cliListen = argv[++i];
-            break;
+            continue;
+        }
+        if (std::string_view(argv[i]) == "--metrics-listen") {
+            metricsListen = argv[++i];
         }
     }
     auto serverPort = cliListen.empty() ? getFromEnv<int>("CACHE_PORT", true) : std::stoi(cliListen);
@@ -22,9 +26,35 @@ int main(int argc, char* argv[]) {
     auto enableCompression = getFromEnv<bool>("ENABLE_COMPRESSION", false, true);
     auto respInlineCapacity = getFromEnv<std::size_t>("RESP_INLINE_CAPACITY", false, static_cast<std::size_t>(255));
 
+    auto metricsHost = std::string{getFromEnv<const char*>("METRICS_HOST", false, "0.0.0.0")};
+    auto metricsPort = getFromEnv<int>("METRICS_PORT", false, 9100);
+    auto metricsPortOffset = getFromEnv<int>("METRICS_PORT_OFFSET", false, 0);
+    auto shardLabel = std::string{getFromEnv<const char*>("PMC_SHARD", false, "0")};
+    auto nodeLabel = std::string{getFromEnv<const char*>("PMC_NODE", false, "local")};
+
+    if (!metricsListen.empty()) {
+        auto colonPos = metricsListen.rfind(':');
+        if (colonPos != std::string::npos) {
+            std::string hostPart = metricsListen.substr(0, colonPos);
+            std::string portPart = metricsListen.substr(colonPos + 1);
+            if (!hostPart.empty()) {
+                metricsHost = hostPart;
+            }
+            metricsPort = std::stoi(portPart);
+        } else {
+            metricsPort = std::stoi(metricsListen);
+        }
+    }
+
+    metricsPort += metricsPortOffset;
+
+    metrics::MetricsConfig metricsConfig{metricsHost, metricsPort, shardLabel, nodeLabel};
+    auto metricsCollector = std::make_shared<metrics::MetricsCollector>(shardLabel, nodeLabel);
+    metrics::MetricsHttpServer metricsServer{metricsConfig, *metricsCollector};
+
     ServerSettings serverSettings { serverPort, numShards, sockBufferSize, connQueueLimit, enableCompression, respInlineCapacity };
 
-    CacheServer cacheServer { serverSettings };
+    CacheServer cacheServer { serverSettings, metricsCollector };
 
     static std::function<void(int)> signalHandler = [&cacheServer](int signal) {
         if (signal == SIGINT || signal == SIGTERM) {
@@ -38,8 +68,9 @@ int main(int argc, char* argv[]) {
         }
     };
 
-    signal(SIGINT, signalDispatcher); 
+    signal(SIGINT, signalDispatcher);
     signal(SIGTERM, signalDispatcher);
 
+    metricsServer.start();
     return cacheServer.Start();
 }

--- a/src/metrics/metrics.cpp
+++ b/src/metrics/metrics.cpp
@@ -1,54 +1,292 @@
 #include "metrics.hpp"
-#include "../server/server.hpp"
-#include "../server/constants.hpp"
+
+#include <arpa/inet.h>
+#include <chrono>
+#include <cstring>
+#include <netinet/in.h>
+#include <sstream>
+#include <stdexcept>
+#include <string_view>
+#include <sys/socket.h>
+#include <unistd.h>
 
 using namespace metrics;
 
-static Histogram::BucketBoundaries CreateLinearBuckets(std::int64_t start, std::int64_t end, std::int64_t step) {
-    auto bucket_boundaries = Histogram::BucketBoundaries{};
-    for (auto i = start; i < end; i += step) {
-        bucket_boundaries.push_back(i);
+namespace {
+
+constexpr std::string_view METRICS_PATH = "/metrics";
+constexpr std::string_view HTTP_GET = "GET";
+
+std::string buildLabels(std::string_view shard, std::string_view node, std::string_view extra = {}) {
+    std::ostringstream oss;
+    oss << '{';
+    if (!extra.empty()) {
+        oss << extra << ',';
     }
-    return bucket_boundaries;
+    oss << "shard=\"" << shard << "\",node=\"" << node << "\"}";
+    return oss.str();
 }
 
-void MetricsServer::RegisterMetrics()
-{
-    server_num_errors_total = &BuildCounter()
-                        .Name("server_num_errors_total")
-                        .Help("Total number of TCP server errors")
-                        .Register(*registry)
-                        .Add({});
-
-    server_num_active_connections = &BuildGauge()
-                        .Name("server_num_active_connections")
-                        .Help("Number of active connections")
-                        .Register(*registry)
-                        .Add({});
-
-    server_num_requests_total = &BuildCounter()
-                        .Name("server_num_requests_total")
-                        .Help("Total number of server requests")
-                        .Register(*registry)
-                        .Add({});
+void appendMetric(std::ostringstream& oss, std::string_view name, std::string_view labels, uint64_t value) {
+    oss << name << labels << ' ' << value << '\n';
 }
 
-MetricsServer::MetricsServer(std::string metrics_url)
-{
-    registry = std::make_shared<Registry>();
-    server = std::make_shared<Exposer>(metrics_url);
-    RegisterMetrics();
-    server.get()->RegisterCollectable(registry);
-    std::cout << "Metrics server started on " << metrics_url << std::endl;
+} // namespace
+
+MetricsCollector::MetricsCollector(std::string shardLabel, std::string nodeLabel)
+    : shard(std::move(shardLabel)), node(std::move(nodeLabel)) {}
+
+void MetricsCollector::incrementRequest(RequestOperation op) noexcept {
+    std::scoped_lock lock(mutex);
+    switch (op) {
+        case RequestOperation::Get:
+            ++metrics.requestsGet;
+            break;
+        case RequestOperation::Set:
+            ++metrics.requestsSet;
+            break;
+        case RequestOperation::Del:
+            ++metrics.requestsDel;
+            break;
+        case RequestOperation::Other:
+        default:
+            ++metrics.requestsOther;
+            break;
+    }
 }
 
-void MetricsServer::UpdateMetrics(CacheServerMetrics& serverMetrics)
-{
-    server_num_active_connections->Set(serverMetrics.numActiveConnections);
+void MetricsCollector::incrementResponse(ResponseStatus status) noexcept {
+    std::scoped_lock lock(mutex);
+    switch (status) {
+        case ResponseStatus::Ok:
+            ++metrics.responsesOk;
+            break;
+        case ResponseStatus::NotFound:
+            ++metrics.responsesNotFound;
+            break;
+        case ResponseStatus::Error:
+        default:
+            ++metrics.responsesError;
+            break;
+    }
+}
 
-    auto numErrorsInc = serverMetrics.numErrors - server_num_errors_total->Value();
-    server_num_errors_total->Increment(numErrorsInc);
+void MetricsCollector::addBytesRx(std::size_t amount) noexcept {
+    std::scoped_lock lock(mutex);
+    metrics.bytesRx += amount;
+}
 
-    auto numRequestsInc = serverMetrics.numRequests - server_num_requests_total->Value();
-    server_num_requests_total->Increment(numRequestsInc);
+void MetricsCollector::addBytesTx(std::size_t amount) noexcept {
+    std::scoped_lock lock(mutex);
+    metrics.bytesTx += amount;
+}
+
+void MetricsCollector::connectionAccepted() noexcept {
+    std::scoped_lock lock(mutex);
+    ++metrics.connectionsAccepted;
+    ++metrics.connectionsCurrent;
+}
+
+void MetricsCollector::connectionClosed(CloseReason reason) noexcept {
+    std::scoped_lock lock(mutex);
+    if (metrics.connectionsCurrent > 0) {
+        --metrics.connectionsCurrent;
+    }
+
+    switch (reason) {
+        case CloseReason::Client:
+            ++metrics.connectionsClosedClient;
+            break;
+        case CloseReason::Error:
+            ++metrics.connectionsClosedError;
+            break;
+        case CloseReason::Server:
+        default:
+            ++metrics.connectionsClosedServer;
+            break;
+    }
+}
+
+void MetricsCollector::recordBatch(std::size_t requestsInBatch) noexcept {
+    std::scoped_lock lock(mutex);
+    ++metrics.batchesTotal;
+    metrics.requestsPerBatchSum += requestsInBatch;
+    ++metrics.requestsPerBatchCount;
+}
+
+void MetricsCollector::setWriteQueueDepth(std::size_t depth) noexcept {
+    std::scoped_lock lock(mutex);
+    metrics.writeQueueDepth = depth;
+}
+
+void MetricsCollector::setReadBufferUsageBytes(std::size_t bytes) noexcept {
+    std::scoped_lock lock(mutex);
+    metrics.readBufferUsageBytes = bytes;
+}
+
+void MetricsCollector::setKvsState(std::size_t items, std::size_t bytesUsed) noexcept {
+    std::scoped_lock lock(mutex);
+    metrics.kvsItems = items;
+    metrics.kvsBytesUsed = bytesUsed;
+}
+
+MetricsSnapshot MetricsCollector::snapshot() const noexcept {
+    std::scoped_lock lock(mutex);
+    return metrics;
+}
+
+std::string MetricsCollector::renderPrometheus() const {
+    auto snap = snapshot();
+    const auto labels = buildLabels(shard, node);
+    std::ostringstream oss;
+
+    appendMetric(oss, "pmc_requests_total", buildLabels(shard, node, "op=\"get\""), snap.requestsGet);
+    appendMetric(oss, "pmc_requests_total", buildLabels(shard, node, "op=\"set\""), snap.requestsSet);
+    appendMetric(oss, "pmc_requests_total", buildLabels(shard, node, "op=\"del\""), snap.requestsDel);
+    appendMetric(oss, "pmc_requests_total", buildLabels(shard, node, "op=\"other\""), snap.requestsOther);
+
+    appendMetric(oss, "pmc_responses_total", buildLabels(shard, node, "status=\"ok\""), snap.responsesOk);
+    appendMetric(oss, "pmc_responses_total", buildLabels(shard, node, "status=\"not_found\""), snap.responsesNotFound);
+    appendMetric(oss, "pmc_responses_total", buildLabels(shard, node, "status=\"error\""), snap.responsesError);
+
+    appendMetric(oss, "pmc_bytes_rx_total", labels, snap.bytesRx);
+    appendMetric(oss, "pmc_bytes_tx_total", labels, snap.bytesTx);
+
+    appendMetric(oss, "pmc_connections_current", labels, snap.connectionsCurrent);
+    appendMetric(oss, "pmc_connections_accepted_total", labels, snap.connectionsAccepted);
+    appendMetric(oss, "pmc_connections_closed_total", buildLabels(shard, node, "reason=\"client\""), snap.connectionsClosedClient);
+    appendMetric(oss, "pmc_connections_closed_total", buildLabels(shard, node, "reason=\"server\""), snap.connectionsClosedServer);
+    appendMetric(oss, "pmc_connections_closed_total", buildLabels(shard, node, "reason=\"error\""), snap.connectionsClosedError);
+
+    appendMetric(oss, "pmc_batches_total", labels, snap.batchesTotal);
+    appendMetric(oss, "pmc_requests_per_batch_sum", labels, snap.requestsPerBatchSum);
+    appendMetric(oss, "pmc_requests_per_batch_count", labels, snap.requestsPerBatchCount);
+
+    appendMetric(oss, "pmc_kvs_items", labels, snap.kvsItems);
+    appendMetric(oss, "pmc_kvs_bytes_used", labels, snap.kvsBytesUsed);
+    appendMetric(oss, "pmc_kvs_evictions_total", labels, snap.kvsEvictions);
+
+    appendMetric(oss, "pmc_write_queue_depth", labels, snap.writeQueueDepth);
+    appendMetric(oss, "pmc_read_buffer_usage_bytes", labels, snap.readBufferUsageBytes);
+
+    return oss.str();
+}
+
+MetricsHttpServer::MetricsHttpServer(MetricsConfig cfg, MetricsCollector& collector)
+    : config(std::move(cfg)), collector(collector) {}
+
+MetricsHttpServer::~MetricsHttpServer() { stop(); }
+
+void MetricsHttpServer::start() {
+    if (running.load()) {
+        return;
+    }
+
+    server_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (!server_fd || *server_fd < 0) {
+        throw std::runtime_error("Failed to create metrics socket");
+    }
+
+    int flag = 1;
+    if (setsockopt(*server_fd, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(flag)) == -1) {
+        throw std::runtime_error("Failed to set SO_REUSEADDR for metrics socket");
+    }
+
+    sockaddr_in address{};
+    address.sin_family = AF_INET;
+    address.sin_port = htons(static_cast<uint16_t>(config.listenPort));
+    address.sin_addr.s_addr = inet_addr(config.listenHost.c_str());
+
+    if (bind(*server_fd, reinterpret_cast<sockaddr*>(&address), sizeof(address)) == -1) {
+        throw std::runtime_error("Failed to bind metrics socket");
+    }
+
+    if (listen(*server_fd, 16) == -1) {
+        throw std::runtime_error("Failed to listen on metrics socket");
+    }
+
+    running = true;
+    worker = std::thread([this]() { serveLoop(); });
+}
+
+void MetricsHttpServer::stop() {
+    if (!running.exchange(false)) {
+        return;
+    }
+
+    if (server_fd && *server_fd >= 0) {
+        ::shutdown(*server_fd, SHUT_RDWR);
+        ::close(*server_fd);
+    }
+
+    if (worker.joinable()) {
+        worker.join();
+    }
+}
+
+void MetricsHttpServer::serveLoop() {
+    while (running.load()) {
+        sockaddr_in client{};
+        socklen_t client_len = sizeof(client);
+        int client_fd = accept(server_fd.value(), reinterpret_cast<sockaddr*>(&client), &client_len);
+        if (client_fd < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            if (!running.load()) {
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            continue;
+        }
+
+        handleClient(client_fd);
+        ::close(client_fd);
+    }
+}
+
+void MetricsHttpServer::handleClient(int client_fd) {
+    constexpr std::size_t BUF_SIZE = 1024;
+    char buffer[BUF_SIZE];
+    ssize_t bytes_read = recv(client_fd, buffer, sizeof(buffer) - 1, 0);
+    if (bytes_read <= 0) {
+        return;
+    }
+
+    buffer[bytes_read] = '\0';
+    std::string_view request(buffer, static_cast<std::size_t>(bytes_read));
+
+    auto endOfLine = request.find('\n');
+    if (endOfLine == std::string_view::npos) {
+        return;
+    }
+
+    auto firstLine = request.substr(0, endOfLine);
+    if (!firstLine.starts_with(HTTP_GET) || firstLine.find(METRICS_PATH) == std::string_view::npos) {
+        return;
+    }
+
+    const auto body = collector.renderPrometheus();
+    std::ostringstream response;
+    response << "HTTP/1.1 200 OK\r\n";
+    response << "Content-Type: text/plain; version=0.0.4\r\n";
+    response << "Content-Length: " << body.size() << "\r\n";
+    response << "Connection: close\r\n\r\n";
+    response << body;
+
+    auto payload = response.str();
+    auto remaining = payload.size();
+    const char* data = payload.data();
+
+    while (remaining > 0) {
+        auto sent = send(client_fd, data, remaining, MSG_NOSIGNAL);
+        if (sent <= 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            break;
+        }
+        remaining -= static_cast<std::size_t>(sent);
+        data += sent;
+    }
 }

--- a/src/metrics/metrics.hpp
+++ b/src/metrics/metrics.hpp
@@ -1,32 +1,114 @@
 #pragma once
-#include <memory>
-#include <format>
-#include <prometheus/exposer.h>
-#include <prometheus/registry.h>
-#include <prometheus/counter.h>
-#include <prometheus/histogram.h>
-#include <prometheus/gauge.h>
-#include "../server/server.hpp"
 
-namespace metrics
-{
-    using namespace prometheus;
-    using namespace server;
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <thread>
 
-    class MetricsServer {
-        private:
-            std::string metrics_url;
-            std::shared_ptr<Registry> registry;
-            std::shared_ptr<Exposer> server;
+namespace metrics {
 
-            Gauge* server_num_active_connections = nullptr;
-            Counter* server_num_requests_total = nullptr;
-            Counter* server_num_errors_total = nullptr;
+enum class RequestOperation : uint8_t {
+    Get,
+    Set,
+    Del,
+    Other,
+};
 
-            void RegisterMetrics();
+enum class ResponseStatus : uint8_t {
+    Ok,
+    NotFound,
+    Error,
+};
 
-        public:
-            MetricsServer(std::string metrics_url);
-            void UpdateMetrics(CacheServerMetrics& serverMetrics);
-    };
-}
+enum class CloseReason : uint8_t {
+    Client,
+    Server,
+    Error,
+};
+
+struct MetricsSnapshot {
+    uint64_t requestsGet = 0;
+    uint64_t requestsSet = 0;
+    uint64_t requestsDel = 0;
+    uint64_t requestsOther = 0;
+
+    uint64_t responsesOk = 0;
+    uint64_t responsesNotFound = 0;
+    uint64_t responsesError = 0;
+
+    uint64_t bytesRx = 0;
+    uint64_t bytesTx = 0;
+
+    uint64_t connectionsCurrent = 0;
+    uint64_t connectionsAccepted = 0;
+    uint64_t connectionsClosedClient = 0;
+    uint64_t connectionsClosedServer = 0;
+    uint64_t connectionsClosedError = 0;
+
+    uint64_t batchesTotal = 0;
+    uint64_t requestsPerBatchSum = 0;
+    uint64_t requestsPerBatchCount = 0;
+
+    uint64_t kvsItems = 0;
+    uint64_t kvsBytesUsed = 0;
+    uint64_t kvsEvictions = 0;
+
+    uint64_t writeQueueDepth = 0;
+    uint64_t readBufferUsageBytes = 0;
+};
+
+struct MetricsConfig {
+    std::string listenHost = "0.0.0.0";
+    int listenPort = 9100;
+    std::string shardLabel = "0";
+    std::string nodeLabel = "local";
+};
+
+class MetricsCollector {
+  public:
+    MetricsCollector(std::string shardLabel, std::string nodeLabel);
+
+    void incrementRequest(RequestOperation op) noexcept;
+    void incrementResponse(ResponseStatus status) noexcept;
+    void addBytesRx(std::size_t amount) noexcept;
+    void addBytesTx(std::size_t amount) noexcept;
+    void connectionAccepted() noexcept;
+    void connectionClosed(CloseReason reason) noexcept;
+    void recordBatch(std::size_t requestsInBatch) noexcept;
+    void setWriteQueueDepth(std::size_t depth) noexcept;
+    void setReadBufferUsageBytes(std::size_t bytes) noexcept;
+    void setKvsState(std::size_t items, std::size_t bytesUsed) noexcept;
+
+    MetricsSnapshot snapshot() const noexcept;
+    std::string renderPrometheus() const;
+
+  private:
+    mutable std::mutex mutex;
+    MetricsSnapshot metrics;
+    const std::string shard;
+    const std::string node;
+};
+
+class MetricsHttpServer {
+  public:
+    MetricsHttpServer(MetricsConfig config, MetricsCollector& collector);
+    ~MetricsHttpServer();
+
+    void start();
+    void stop();
+
+  private:
+    void serveLoop();
+    void handleClient(int client_fd);
+
+    MetricsConfig config;
+    MetricsCollector& collector;
+    std::optional<int> server_fd;
+    std::thread worker;
+    std::atomic<bool> running{false};
+};
+
+} // namespace metrics

--- a/src/server/conn_manager.hpp
+++ b/src/server/conn_manager.hpp
@@ -16,6 +16,7 @@
 #include "../kvs/kvs.hpp"
 #include "../utils/time.hpp"
 #include "../non_copyable.hpp"
+#include "../metrics/metrics.hpp"
 #include "coroutines.hpp"
 #include "sockutils.hpp"
 #include "constants.hpp"
@@ -99,6 +100,7 @@ namespace server {
             std::deque<RequestView> pendingRequests;
             size_t bytesToErase = 0;
             std::unique_ptr<RespTransactionState> respTransaction;
+            metrics::MetricsCollector* metrics = nullptr;
 
             void queueResponseChunk(const char* data, std::size_t len, RequestProtocol protocol) noexcept
             {
@@ -183,6 +185,10 @@ namespace server {
 
                     remaining -= written;
 
+                    if (metrics) {
+                        metrics->addBytesTx(written);
+                    }
+
                     while (written > 0) {
                         const auto& ch = wb.chunks[idx];
                         auto chunkRemaining = ch.len - offsetInside;
@@ -237,7 +243,8 @@ namespace server {
             }
 
             ConnectionData() = default;
-            ConnectionData(timespec ts, int epfd) : lastActivity(ts), epoll_fd(epfd) {
+            ConnectionData(timespec ts, int epfd, metrics::MetricsCollector* metricsCollector = nullptr)
+                : lastActivity(ts), epoll_fd(epfd), metrics(metricsCollector) {
                 readBuffer.reserve(READ_BUFFER_SIZE);
             }
             ~ConnectionData();
@@ -265,12 +272,15 @@ namespace server {
                 }
                 timespec time{0, 0};
                 if (clock_gettime(CLOCK_MONOTONIC_COARSE, &time) == 0) {
-                    auto [iterator, success] = connections.try_emplace(client_fd, time, epoll_fd );
+                    auto [iterator, success] = connections.try_emplace(client_fd, time, epoll_fd, metrics);
                     if (!success) {
 #ifndef NDEBUG
                         std::cerr << "Connection info already exists for client_fd = " << client_fd << ", epoll_fd = " << epoll_fd << std::endl;
 #endif
                         return 0;
+                    }
+                    if (metrics) {
+                        metrics->connectionAccepted();
                     }
                 } else {
                     perror("clock_gettime() failed when registering connection");
@@ -311,7 +321,7 @@ namespace server {
                 return true;
             };
 
-            void closeConnection(int fd) noexcept {
+            void closeConnection(int fd, metrics::CloseReason reason = metrics::CloseReason::Server) noexcept {
                 std::lock_guard<std::mutex> lock(conn_mutex);
                 if (!connections.contains(fd)) {
                     return;
@@ -330,6 +340,9 @@ namespace server {
 #ifndef NDEBUG
                     perror("Error when closing socket descriptor");
 #endif
+                }
+                if (metrics) {
+                    metrics->connectionClosed(reason);
                 }
                 connections.erase(fd);
             };
@@ -379,7 +392,12 @@ namespace server {
                 co_return 0;
             }
 
-            ConnManager(int epoll_fd): epoll_fd(epoll_fd) {}
+            ConnManager(int epoll_fd, metrics::MetricsCollector* metrics = nullptr): epoll_fd(epoll_fd), metrics(metrics) {}
+
+            void setMetrics(metrics::MetricsCollector* m) noexcept { metrics = m; }
+
+        private:
+            metrics::MetricsCollector* metrics = nullptr;
     };
 }
 

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -1,4 +1,5 @@
 #include "server.hpp"
+#include <algorithm>
 #include <unordered_map>
 #include <string>
 #include <vector>
@@ -7,7 +8,8 @@ using namespace server;
 
 ConnectionData::~ConnectionData() = default;
 
-CacheServer::CacheServer(const ServerSettings settings): numShards(settings.numShards), port(settings.port)
+CacheServer::CacheServer(const ServerSettings settings, std::shared_ptr<metrics::MetricsCollector> metricsCollector)
+    : numShards(settings.numShards), port(settings.port), metrics(std::move(metricsCollector))
 {
     setRespInlineCapacity(settings.respInlineCapacity);
 
@@ -70,7 +72,7 @@ CacheServer::CacheServer(const ServerSettings settings): numShards(settings.numS
         throw std::system_error(errno, std::system_category(), "Failed to create epoll instance");
     }
 
-    connManager = std::make_unique<ConnManager>(epoll_fd);
+    connManager = std::make_unique<ConnManager>(epoll_fd, metrics.get());
 
 #ifndef NDEBUG
     std::cout << "Initializing " << numShards << " server shards…\n";
@@ -94,19 +96,45 @@ CacheServer::~CacheServer() {
 
 ResponsePacket CacheServer::processRequestSync(const RequestView& request, ConnectionData& connData)
 {
+    auto recordRequest = [&](metrics::RequestOperation op) {
+        if (metrics) {
+            metrics->incrementRequest(op);
+        }
+    };
+
+    auto recordResponse = [&](metrics::ResponseStatus status) {
+        if (metrics) {
+            metrics->incrementResponse(status);
+        }
+    };
+
     auto handleGet = [&](const char* keyPtr, RequestProtocol protocol) -> ResponsePacket {
+        recordRequest(metrics::RequestOperation::Get);
         auto hash = hashFunc(keyPtr);
         auto& shard = serverShards[hash % numShards];
         Query query{QueryCode::GET, keyPtr, hash};
         auto result = shard.processQuery(query);
+        if (result == NOTHING) {
+            recordResponse(metrics::ResponseStatus::NotFound);
+        } else if (result) {
+            recordResponse(metrics::ResponseStatus::Ok);
+        } else {
+            recordResponse(metrics::ResponseStatus::Error);
+        }
         return protocol == RequestProtocol::RESP ? makeRespBulkString(result) : makeCustomResponse(result);
     };
 
     auto handleSet = [&](const char* keyPtr, const char* valuePtr, RequestProtocol protocol) -> ResponsePacket {
+        recordRequest(metrics::RequestOperation::Set);
         auto hash = hashFunc(keyPtr);
         auto& shard = serverShards[hash % numShards];
         Command cmd{CommandCode::SET, keyPtr, valuePtr, hash};
         auto result = shard.processCommand(cmd);
+        if (result && std::strcmp(result, OK) == 0) {
+            recordResponse(metrics::ResponseStatus::Ok);
+        } else {
+            recordResponse(metrics::ResponseStatus::Error);
+        }
         if (protocol == RequestProtocol::RESP) {
             return (result && std::strcmp(result, OK) == 0) ? makeRespSimpleString(result) : makeRespError(result);
         }
@@ -114,18 +142,29 @@ ResponsePacket CacheServer::processRequestSync(const RequestView& request, Conne
     };
 
     auto handleDel = [&](const char* keyPtr, RequestProtocol protocol) -> ResponsePacket {
+        recordRequest(metrics::RequestOperation::Del);
         auto hash = hashFunc(keyPtr);
         auto& shard = serverShards[hash % numShards];
         Command cmd{CommandCode::DEL, keyPtr, nullptr, hash};
         auto result = shard.processCommand(cmd);
         if (protocol == RequestProtocol::RESP) {
             if (result && std::strcmp(result, OK) == 0) {
+                recordResponse(metrics::ResponseStatus::Ok);
                 return makeRespInteger(1);
             }
             if (result && std::strcmp(result, KEY_NOT_EXISTS) == 0) {
+                recordResponse(metrics::ResponseStatus::NotFound);
                 return makeRespInteger(0);
             }
+            recordResponse(metrics::ResponseStatus::Error);
             return makeRespError(result);
+        }
+        if (result && std::strcmp(result, OK) == 0) {
+            recordResponse(metrics::ResponseStatus::Ok);
+        } else if (result && std::strcmp(result, KEY_NOT_EXISTS) == 0) {
+            recordResponse(metrics::ResponseStatus::NotFound);
+        } else {
+            recordResponse(metrics::ResponseStatus::Error);
         }
         return makeCustomResponse(result);
     };
@@ -145,8 +184,10 @@ ResponsePacket CacheServer::processRequestSync(const RequestView& request, Conne
         };
 
         auto queueRespCommand = [&](RespTransactionState::CommandType type, const char* key, const char* value) -> ResponsePacket {
+            recordRequest(metrics::RequestOperation::Other);
             auto& tx = ensureRespTransaction();
             if (!tx.active) {
+                recordResponse(metrics::ResponseStatus::Error);
                 ++numErrors;
                 return makeRespError(RESP_ERR_EXEC_NO_MULTI);
             }
@@ -155,19 +196,24 @@ ResponsePacket CacheServer::processRequestSync(const RequestView& request, Conne
             queued.type = type;
             queued.key = tx.persistString(key);
             queued.value = tx.persistString(value);
+            recordResponse(metrics::ResponseStatus::Ok);
             return makeRespSimpleString(QUEUED_STR);
         };
 
         RespCommandParts parts{};
         if (!parseRespCommand(request.payload, parts)) {
+            recordRequest(metrics::RequestOperation::Other);
+            recordResponse(metrics::ResponseStatus::Error);
             ++numErrors;
             markRespTransactionError();
             return makeErrorResponse(RequestProtocol::RESP, UNABLE_TO_PARSE_REQUEST_ERROR);
         }
 
         if (std::strcmp(parts.command, MULTI_STR) == 0) {
+            recordRequest(metrics::RequestOperation::Other);
             auto& tx = ensureRespTransaction();
             if (tx.active) {
+                recordResponse(metrics::ResponseStatus::Error);
                 ++numErrors;
                 markRespTransactionError();
                 return makeRespError(RESP_ERR_MULTI_NESTED);
@@ -175,11 +221,14 @@ ResponsePacket CacheServer::processRequestSync(const RequestView& request, Conne
             tx.active = true;
             tx.aborted = false;
             tx.clearQueue();
+            recordResponse(metrics::ResponseStatus::Ok);
             return makeRespSimpleString(OK);
         }
 
         if (std::strcmp(parts.command, DISCARD_STR) == 0) {
+            recordRequest(metrics::RequestOperation::Other);
             if (!connData.respTransaction || !connData.respTransaction->active) {
+                recordResponse(metrics::ResponseStatus::Error);
                 ++numErrors;
                 return makeRespError(RESP_ERR_DISCARD_NO_MULTI);
             }
@@ -187,11 +236,14 @@ ResponsePacket CacheServer::processRequestSync(const RequestView& request, Conne
             tx.clearQueue();
             tx.active = false;
             tx.aborted = false;
+            recordResponse(metrics::ResponseStatus::Ok);
             return makeRespSimpleString(OK);
         }
 
         if (std::strcmp(parts.command, EXEC_STR) == 0) {
+            recordRequest(metrics::RequestOperation::Other);
             if (!connData.respTransaction || !connData.respTransaction->active) {
+                recordResponse(metrics::ResponseStatus::Error);
                 ++numErrors;
                 return makeRespError(RESP_ERR_EXEC_NO_MULTI);
             }
@@ -201,6 +253,7 @@ ResponsePacket CacheServer::processRequestSync(const RequestView& request, Conne
                 tx.active = false;
                 tx.aborted = false;
                 ++numErrors;
+                recordResponse(metrics::ResponseStatus::Error);
                 return makeRespError(RESP_ERR_EXEC_ABORTED);
             }
             std::vector<ResponsePacket> results;
@@ -221,11 +274,14 @@ ResponsePacket CacheServer::processRequestSync(const RequestView& request, Conne
             tx.clearQueue();
             tx.active = false;
             tx.aborted = false;
+            recordResponse(metrics::ResponseStatus::Ok);
             return makeRespArray(results);
         }
 
         if (std::strcmp(parts.command, GET_STR) == 0) {
             if (parts.argc != 2) {
+                recordRequest(metrics::RequestOperation::Other);
+                recordResponse(metrics::ResponseStatus::Error);
                 ++numErrors;
                 markRespTransactionError();
                 return makeErrorResponse(RequestProtocol::RESP, INVALID_COMMAND_FORMAT);
@@ -238,6 +294,8 @@ ResponsePacket CacheServer::processRequestSync(const RequestView& request, Conne
 
         if (std::strcmp(parts.command, SET_STR) == 0) {
             if (parts.argc != 3 || parts.value == nullptr) {
+                recordRequest(metrics::RequestOperation::Other);
+                recordResponse(metrics::ResponseStatus::Error);
                 ++numErrors;
                 markRespTransactionError();
                 return makeErrorResponse(RequestProtocol::RESP, INVALID_COMMAND_FORMAT);
@@ -250,6 +308,8 @@ ResponsePacket CacheServer::processRequestSync(const RequestView& request, Conne
 
         if (std::strcmp(parts.command, DEL_STR) == 0) {
             if (parts.argc != 2) {
+                recordRequest(metrics::RequestOperation::Other);
+                recordResponse(metrics::ResponseStatus::Error);
                 ++numErrors;
                 markRespTransactionError();
                 return makeErrorResponse(RequestProtocol::RESP, INVALID_COMMAND_FORMAT);
@@ -261,6 +321,8 @@ ResponsePacket CacheServer::processRequestSync(const RequestView& request, Conne
         }
 
         ++numErrors;
+        recordRequest(metrics::RequestOperation::Other);
+        recordResponse(metrics::ResponseStatus::Error);
         markRespTransactionError();
         return makeErrorResponse(RequestProtocol::RESP, UNKNOWN_COMMAND);
     }
@@ -268,6 +330,8 @@ ResponsePacket CacheServer::processRequestSync(const RequestView& request, Conne
     const auto firstSpace = request.payload.find(' ');
     if (firstSpace == std::string_view::npos) {
         ++numErrors;
+        recordRequest(metrics::RequestOperation::Other);
+        recordResponse(metrics::ResponseStatus::Error);
         return makeErrorResponse(RequestProtocol::Custom, UNABLE_TO_PARSE_REQUEST_ERROR);
     }
 
@@ -275,6 +339,8 @@ ResponsePacket CacheServer::processRequestSync(const RequestView& request, Conne
     const auto remainder = request.payload.substr(firstSpace + 1);
     if (remainder.empty()) {
         ++numErrors;
+        recordRequest(metrics::RequestOperation::Other);
+        recordResponse(metrics::ResponseStatus::Error);
         return makeErrorResponse(RequestProtocol::Custom, INVALID_COMMAND_FORMAT);
     }
 
@@ -288,21 +354,27 @@ ResponsePacket CacheServer::processRequestSync(const RequestView& request, Conne
     }
 
     if (command == GET_STR) {
+        recordRequest(metrics::RequestOperation::Get);
         return handleGet(keyPtr, RequestProtocol::Custom);
     }
 
     if (command == SET_STR) {
+        recordRequest(metrics::RequestOperation::Set);
         if (!valuePtr) {
             ++numErrors;
+            recordResponse(metrics::ResponseStatus::Error);
             return makeErrorResponse(RequestProtocol::Custom, INVALID_COMMAND_FORMAT);
         }
         return handleSet(keyPtr, valuePtr, RequestProtocol::Custom);
     }
 
     if (command == DEL_STR) {
+        recordRequest(metrics::RequestOperation::Del);
         return handleDel(keyPtr, RequestProtocol::Custom);
     }
 
+    recordRequest(metrics::RequestOperation::Other);
+    recordResponse(metrics::ResponseStatus::Error);
     ++numErrors;
     return makeErrorResponse(RequestProtocol::Custom, UNKNOWN_COMMAND);
 }
@@ -343,7 +415,7 @@ HandleReqTask CacheServer::handleRequests()
                     }
 
                     if (!it->second.flushWriteBatch(fd)) {
-                        connManager->closeConnection(fd);
+                        connManager->closeConnection(fd, metrics::CloseReason::Error);
                     }
                 }
             }
@@ -352,10 +424,11 @@ HandleReqTask CacheServer::handleRequests()
             std::vector<AsyncReadTask> readers;
             readers.reserve(MAX_EVENTS);
             numRequests += event_count;
+            std::size_t processedRequests = 0;
             for (int i = 0; i < event_count; ++i) {
                 auto client_fd = epoll_events[i].data.fd;
                 if ((epoll_events[i].events & (EPOLLERR | EPOLLHUP))) {
-                    connManager->closeConnection(client_fd);
+                    connManager->closeConnection(client_fd, metrics::CloseReason::Error);
                     continue;
                 }
 
@@ -363,7 +436,7 @@ HandleReqTask CacheServer::handleRequests()
                     auto it = connManager->connections.find(client_fd);
                     if (it != connManager->connections.end()) {
                         if (!it->second.flushWriteBatch(client_fd)) {
-                            connManager->closeConnection(client_fd);
+                            connManager->closeConnection(client_fd, metrics::CloseReason::Error);
                             continue;
                         }
                     }
@@ -394,14 +467,20 @@ HandleReqTask CacheServer::handleRequests()
                 while (!connData.pendingRequests.empty()) {
                     auto req = connData.pendingRequests.front();
                     connData.pendingRequests.pop_front();
+                    ++processedRequests;
                     responses.emplace_back(processRequestSync(req, connData));
                 }
                 if (connData.bytesToErase > 0) {
+                    bufferedReadBytes -= std::min<std::size_t>(bufferedReadBytes, connData.bytesToErase);
                     connData.readBuffer.erase(connData.readBuffer.begin(), connData.readBuffer.begin() + connData.bytesToErase);
                     connData.bytesToErase = 0;
+                    if (metrics) {
+                        metrics->setReadBufferUsageBytes(bufferedReadBytes);
+                    }
                 }
             }
 
+            std::size_t queuedBytes = 0;
             for (auto& [fd, responses] : responsesPerConn) {
                 if (responses.empty())
                     continue;
@@ -413,13 +492,25 @@ HandleReqTask CacheServer::handleRequests()
                 ConnectionData& conn = it->second;
 
                 for (const auto& resp : responses) {
+                    queuedBytes += resp.size;
                     conn.queueResponseChunk(resp.data, resp.size, resp.protocol);
+                    if (resp.protocol == RequestProtocol::Custom) {
+                        queuedBytes += 1;
+                    }
                 }
 
                 if(!conn.flushWriteBatch(fd)) {
                     ++numErrors;
-                    connManager->closeConnection(fd);
+                    connManager->closeConnection(fd, metrics::CloseReason::Error);
                 };
+            }
+
+            if (metrics) {
+                metrics->setWriteQueueDepth(queuedBytes);
+                metrics->recordBatch(processedRequests);
+                if (processedRequests > 0) {
+                    updateKvsMetrics();
+                }
             }
 
 #ifndef NDEBUG
@@ -456,11 +547,20 @@ AsyncReadTask server::CacheServer::readRequestAsync(int client_fd)
         }
 
         if (bytes_read == 0) {
-            connManager->closeConnection(client_fd);
+            bufferedReadBytes -= std::min<std::size_t>(bufferedReadBytes, connData.readBuffer.size());
+            if (metrics) {
+                metrics->setReadBufferUsageBytes(bufferedReadBytes);
+            }
+            connManager->closeConnection(client_fd, metrics::CloseReason::Client);
             co_return ReadRequestResult{ ReqReadOperationResult::Failure };
         }
 
         connData.readBuffer.insert(connData.readBuffer.end(), buffer, buffer + bytes_read);
+        bufferedReadBytes += static_cast<std::size_t>(bytes_read);
+        if (metrics) {
+            metrics->addBytesRx(static_cast<std::size_t>(bytes_read));
+            metrics->setReadBufferUsageBytes(bufferedReadBytes);
+        }
         ++read_attempts;
     }
 
@@ -484,7 +584,11 @@ AsyncReadTask server::CacheServer::readRequestAsync(int client_fd)
                 connData.pendingRequests.clear();
                 connData.readBuffer.clear();
                 connData.bytesToErase = 0;
-                connManager->closeConnection(client_fd);
+                bufferedReadBytes = 0;
+                if (metrics) {
+                    metrics->setReadBufferUsageBytes(bufferedReadBytes);
+                }
+                connManager->closeConnection(client_fd, metrics::CloseReason::Error);
                 co_return ReadRequestResult{ ReqReadOperationResult::Failure };
             }
 
@@ -514,6 +618,10 @@ AsyncReadTask server::CacheServer::readRequestAsync(int client_fd)
 
     if (start > 0) {
         connData.bytesToErase += start;
+    }
+
+    if (metrics) {
+        metrics->setReadBufferUsageBytes(bufferedReadBytes);
     }
 
     if (parsed) {
@@ -568,6 +676,9 @@ void CacheServer::sendResponses(int client_fd, const std::vector<ResponsePacket>
         }
 
         totalSent += bytesSent;
+        if (metrics) {
+            metrics->addBytesTx(static_cast<std::size_t>(bytesSent));
+        }
 
         while (bytesSent > 0 && iov_idx < iov.size()) {
             if (static_cast<size_t>(bytesSent) >= iov[iov_idx].iov_len) {
@@ -583,6 +694,20 @@ void CacheServer::sendResponses(int client_fd, const std::vector<ResponsePacket>
         msg.msg_iov = &iov[iov_idx];
         msg.msg_iovlen = iov.size() - iov_idx;
     }
+}
+
+void CacheServer::updateKvsMetrics()
+{
+    if (!metrics) {
+        return;
+    }
+
+    uint64_t totalItems = 0;
+    for (const auto& shard : serverShards) {
+        totalItems += shard.keyValueStore->getNumEntries();
+    }
+
+    metrics->setKvsState(totalItems, 0);
 }
 
 int CacheServer::Start()

--- a/src/server/server.hpp
+++ b/src/server/server.hpp
@@ -19,6 +19,7 @@
 #include <netinet/tcp.h>
 #include "../hash/hash.hpp"
 #include "../non_copyable.hpp"
+#include "../metrics/metrics.hpp"
 #include "sockutils.hpp"
 #include "conn_manager.hpp"
 #include "shard.hpp"
@@ -106,6 +107,8 @@ namespace server {
             std::atomic<uint_fast64_t> numErrors = 0;
             std::atomic<uint_fast64_t> numRequests = 0;
             std::atomic<bool> isRunning = false;
+            std::shared_ptr<metrics::MetricsCollector> metrics;
+            std::size_t bufferedReadBytes = 0;
 
             uint_fast16_t numShards;
             std::vector<ServerShard> serverShards;
@@ -118,8 +121,9 @@ namespace server {
             ResponsePacket processRequestSync(const RequestView& request, ConnectionData& connData);
             HandleReqTask handleRequests();
             void sendResponses(int client_fd, const std::vector<ResponsePacket>& responses);
+            void updateKvsMetrics();
         public:
-            CacheServer(const ServerSettings settings = ServerSettings{});
+            CacheServer(const ServerSettings settings = ServerSettings{}, std::shared_ptr<metrics::MetricsCollector> metrics = nullptr);
             ~CacheServer();
 
             /// @brief Starts processing incoming requests


### PR DESCRIPTION
### Motivation

- Ensure the bundled Grafana dashboard is auto-imported and Grafana has a working Prometheus datasource. 
- Eliminate Mimir errors about insufficient ingester replicas for local/single-node setups. 
- Replace the heavyweight external prometheus-cpp dependency with a lightweight in-process metrics server and expose per-shard metrics. 
- Provide a small cluster controller that publishes an HTTP discovery endpoint so Alloy/Prometheus SD can discover shards automatically.

### Description

- Fix Grafana provisioning by using the correct `providers` key and add `observability/grafana/pmc-cluster.json` and a provisioning datasource so the "Poor Man's Cache - Cluster" dashboard is auto-imported. 
- Add `observability/mimir/mimir.yaml` configured for single-node testing with `ingester.ring.replication_factor: 1` and `kvstore: inmemory` to avoid "at least 2 live replicas" errors. 
- Add a cluster controller (module renamed to `cluster-controller`) that computes/adjusts metrics port base, exposes `/discovery` emitting Prometheus HTTP SD target groups, and include unit tests in `launcher/discovery_test.go`. 
- Remove `prometheus-cpp` dependency references and replace with an in-process metrics collector and HTTP server under `src/metrics/*`, and wire the collector into server lifecycle (`src/main.cpp`, `src/server/*`, `src/server/conn_manager.hpp`) to record requests, responses, bytes, connections, and KVS state. 
- Update compose/build artifacts and docs: switch metrics ports to `9100`, build/install the cluster controller binary in Dockerfiles, update `CMakeLists.txt` to drop `prometheus-cpp` requirements, and update README and compose templates to include `mimir`, `alloy`, and `grafana` monitoring services and discovery wiring.

### Testing

- Rendered the Jinja compose template with a one-off Python renderer to materialize `/tmp/docker-compose.rendered.yaml`, and the rendering completed successfully (pass). 
- Verified the Grafana provisioning file and dashboard JSON are present and that `observability/mimir/mimir.yaml` contains the single-node ring settings (inspection pass). 
- Added Go unit tests for discovery and port resolution (`launcher/discovery_test.go`), but `go test` was not executed in this environment (not run). 
- Container validation (`docker compose`), C++ build, and integration test runs were not executed here due to the runtime/CLI constraints (not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693590066d1483338667fcccf8275f4b)