### PR TITLE
Observability: add Grafana units and remove unused KVS eviction metric

### DIFF
--- a/observability/grafana/pmc-cluster.json
+++ b/observability/grafana/pmc-cluster.json
@@ -4,133 +4,343 @@
   "schemaVersion": 38,
   "version": 1,
   "refresh": "5s",
-  "tags": ["pmc", "cache"],
+  "tags": [
+    "pmc",
+    "cache"
+  ],
   "panels": [
     {
       "type": "timeseries",
       "title": "Request rate by operation",
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
       "targets": [
-        {"expr": "sum(rate(pmc_requests_total{op=\"get\"}[1m]))", "legendFormat": "get"},
-        {"expr": "sum(rate(pmc_requests_total{op=\"set\"}[1m]))", "legendFormat": "set"},
-        {"expr": "sum(rate(pmc_requests_total{op=\"del\"}[1m]))", "legendFormat": "del"},
-        {"expr": "sum(rate(pmc_requests_total{op=\"other\"}[1m]))", "legendFormat": "other"}
-      ]
+        {
+          "expr": "sum(rate(pmc_requests_total{op=\"get\"}[1m]))",
+          "legendFormat": "get"
+        },
+        {
+          "expr": "sum(rate(pmc_requests_total{op=\"set\"}[1m]))",
+          "legendFormat": "set"
+        },
+        {
+          "expr": "sum(rate(pmc_requests_total{op=\"del\"}[1m]))",
+          "legendFormat": "del"
+        },
+        {
+          "expr": "sum(rate(pmc_requests_total{op=\"other\"}[1m]))",
+          "legendFormat": "other"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      }
     },
     {
       "type": "timeseries",
       "title": "Responses by status",
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
       "targets": [
-        {"expr": "sum(rate(pmc_responses_total{status=\"ok\"}[1m]))", "legendFormat": "ok"},
-        {"expr": "sum(rate(pmc_responses_total{status=\"not_found\"}[1m]))", "legendFormat": "not_found"},
-        {"expr": "sum(rate(pmc_responses_total{status=\"error\"}[1m]))", "legendFormat": "error"}
-      ]
+        {
+          "expr": "sum(rate(pmc_responses_total{status=\"ok\"}[1m]))",
+          "legendFormat": "ok"
+        },
+        {
+          "expr": "sum(rate(pmc_responses_total{status=\"not_found\"}[1m]))",
+          "legendFormat": "not_found"
+        },
+        {
+          "expr": "sum(rate(pmc_responses_total{status=\"error\"}[1m]))",
+          "legendFormat": "error"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      }
     },
     {
       "type": "timeseries",
       "title": "Request rate per shard",
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
       "targets": [
-        {"expr": "sum by (shard) (rate(pmc_requests_total[1m]))", "legendFormat": "shard {{shard}}"}
-      ]
+        {
+          "expr": "sum by (shard) (rate(pmc_requests_total[1m]))",
+          "legendFormat": "shard {{shard}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      }
     },
     {
       "type": "timeseries",
       "title": "Bytes in/out per shard",
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
       "targets": [
-        {"expr": "sum by (shard) (rate(pmc_bytes_rx_total[1m]))", "legendFormat": "rx shard {{shard}}"},
-        {"expr": "sum by (shard) (rate(pmc_bytes_tx_total[1m]))", "legendFormat": "tx shard {{shard}}"}
-      ]
+        {
+          "expr": "sum by (shard) (rate(pmc_bytes_rx_total[1m]))",
+          "legendFormat": "rx shard {{shard}}"
+        },
+        {
+          "expr": "sum by (shard) (rate(pmc_bytes_tx_total[1m]))",
+          "legendFormat": "tx shard {{shard}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps"
+        },
+        "overrides": []
+      }
     },
     {
       "type": "stat",
       "title": "Connections",
-      "gridPos": {"h": 6, "w": 6, "x": 0, "y": 16},
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 16
+      },
       "targets": [
-        {"expr": "sum(pmc_connections_current)", "legendFormat": "current"},
-        {"expr": "sum(pmc_connections_accepted_total)", "legendFormat": "accepted"}
+        {
+          "expr": "sum(pmc_connections_current)",
+          "legendFormat": "current"
+        },
+        {
+          "expr": "sum(pmc_connections_accepted_total)",
+          "legendFormat": "accepted"
+        }
       ],
-      "options": {"reduceOptions": {"calcs": ["last"]}}
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      }
     },
     {
       "type": "timeseries",
       "title": "Connection closures by reason",
-      "gridPos": {"h": 6, "w": 6, "x": 6, "y": 16},
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 16
+      },
       "targets": [
-        {"expr": "sum(rate(pmc_connections_closed_total{reason=\"client\"}[1m]))", "legendFormat": "client"},
-        {"expr": "sum(rate(pmc_connections_closed_total{reason=\"server\"}[1m]))", "legendFormat": "server"},
-        {"expr": "sum(rate(pmc_connections_closed_total{reason=\"error\"}[1m]))", "legendFormat": "error"}
-      ]
+        {
+          "expr": "sum(rate(pmc_connections_closed_total{reason=\"client\"}[1m]))",
+          "legendFormat": "client"
+        },
+        {
+          "expr": "sum(rate(pmc_connections_closed_total{reason=\"server\"}[1m]))",
+          "legendFormat": "server"
+        },
+        {
+          "expr": "sum(rate(pmc_connections_closed_total{reason=\"error\"}[1m]))",
+          "legendFormat": "error"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      }
     },
     {
       "type": "timeseries",
       "title": "Write queue depth",
-      "gridPos": {"h": 6, "w": 6, "x": 12, "y": 16},
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 16
+      },
       "targets": [
-        {"expr": "sum(pmc_write_queue_depth)", "legendFormat": "depth"}
-      ]
+        {
+          "expr": "sum(pmc_write_queue_depth)",
+          "legendFormat": "depth"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      }
     },
     {
       "type": "timeseries",
       "title": "Read buffer usage",
-      "gridPos": {"h": 6, "w": 6, "x": 18, "y": 16},
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 16
+      },
       "targets": [
-        {"expr": "sum(pmc_read_buffer_usage_bytes)", "legendFormat": "bytes"}
-      ]
+        {
+          "expr": "sum(pmc_read_buffer_usage_bytes)",
+          "legendFormat": "bytes"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      }
     },
     {
       "type": "timeseries",
       "title": "Bytes in/out",
-      "gridPos": {"h": 6, "w": 12, "x": 0, "y": 22},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
       "targets": [
-        {"expr": "sum(rate(pmc_bytes_rx_total[1m]))", "legendFormat": "rx"},
-        {"expr": "sum(rate(pmc_bytes_tx_total[1m]))", "legendFormat": "tx"}
-      ]
+        {
+          "expr": "sum(rate(pmc_bytes_rx_total[1m]))",
+          "legendFormat": "rx"
+        },
+        {
+          "expr": "sum(rate(pmc_bytes_tx_total[1m]))",
+          "legendFormat": "tx"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps"
+        },
+        "overrides": []
+      }
     },
     {
       "type": "timeseries",
       "title": "Batch rate",
-      "gridPos": {"h": 6, "w": 6, "x": 12, "y": 22},
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 22
+      },
       "targets": [
-        {"expr": "sum(rate(pmc_batches_total[1m]))", "legendFormat": "batches"}
-      ]
+        {
+          "expr": "sum(rate(pmc_batches_total[1m]))",
+          "legendFormat": "batches"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      }
     },
     {
       "type": "timeseries",
       "title": "Average requests per batch",
-      "gridPos": {"h": 6, "w": 6, "x": 18, "y": 22},
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 22
+      },
       "targets": [
         {
           "expr": "sum(rate(pmc_requests_per_batch_sum[1m])) / sum(rate(pmc_requests_per_batch_count[1m]))",
           "legendFormat": "avg"
         }
-      ]
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      }
     },
     {
       "type": "timeseries",
       "title": "KVS items",
-      "gridPos": {"h": 6, "w": 6, "x": 0, "y": 28},
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 28
+      },
       "targets": [
-        {"expr": "sum(pmc_kvs_items)", "legendFormat": "items"}
-      ]
+        {
+          "expr": "sum(pmc_kvs_items)",
+          "legendFormat": "items"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      }
     },
     {
       "type": "timeseries",
       "title": "KVS bytes used",
-      "gridPos": {"h": 6, "w": 6, "x": 6, "y": 28},
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 28
+      },
       "targets": [
-        {"expr": "sum(pmc_kvs_bytes_used)", "legendFormat": "bytes"}
-      ]
-    },
-    {
-      "type": "timeseries",
-      "title": "KVS evictions",
-      "gridPos": {"h": 6, "w": 6, "x": 12, "y": 28},
-      "targets": [
-        {"expr": "sum(rate(pmc_kvs_evictions_total[1m]))", "legendFormat": "evictions"}
-      ]
+        {
+          "expr": "sum(pmc_kvs_bytes_used)",
+          "legendFormat": "bytes"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      }
     }
   ]
 }

--- a/src/metrics/metrics.cpp
+++ b/src/metrics/metrics.cpp
@@ -164,8 +164,6 @@ std::string MetricsCollector::renderPrometheus() const {
 
     appendMetric(oss, "pmc_kvs_items", labels, snap.kvsItems);
     appendMetric(oss, "pmc_kvs_bytes_used", labels, snap.kvsBytesUsed);
-    appendMetric(oss, "pmc_kvs_evictions_total", labels, snap.kvsEvictions);
-
     appendMetric(oss, "pmc_write_queue_depth", labels, snap.writeQueueDepth);
     appendMetric(oss, "pmc_read_buffer_usage_bytes", labels, snap.readBufferUsageBytes);
 

--- a/src/metrics/metrics.hpp
+++ b/src/metrics/metrics.hpp
@@ -54,8 +54,6 @@ struct MetricsSnapshot {
 
     uint64_t kvsItems = 0;
     uint64_t kvsBytesUsed = 0;
-    uint64_t kvsEvictions = 0;
-
     uint64_t writeQueueDepth = 0;
     uint64_t readBufferUsageBytes = 0;
 };


### PR DESCRIPTION
### Motivation
- Make Grafana panels show correct units (ops, Bps, bytes, counts) so metrics are easier to interpret. 
- The `kvsEvictions` counter was always zero in dashboards and appeared unused, so remove the misleading metric and its panel. 
- Ensure other exported metrics remain populated and visible after the change.

### Description
- Added `fieldConfig.defaults.unit` to every panel in `observability/grafana/pmc-cluster.json` (units include `ops`, `Bps`, `bytes`, `short`) so Grafana renders values with the correct units. 
- Removed the `KVS evictions` panel from the Grafana cluster dashboard. 
- Dropped the unused `kvsEvictions` field from `MetricsSnapshot` and stopped emitting `pmc_kvs_evictions_total` from the Prometheus output in `src/metrics/metrics.cpp`/`src/metrics/metrics.hpp`. 
- No other metric names or collection logic were changed; request/response/traffic/connection/batch/KVS metrics are left intact.

### Testing
- Ran unit and integration suite with `./scripts/run-all-tests.bash` and all tests passed. 
- Built the project (`cmake --build out/build/Release -j`) successfully. 
- Ran functional workload against a locally started server using the test harness (`TEST_ITERATIONS=200 TEST_POOL_SIZE=2 TEST_DELAY_SEC=0.01 python3 tests/tcp_server_test.py`) and observed no failures. 
- Verified the metrics endpoint (`curl http://127.0.0.1:9100/metrics`) to confirm other metrics are present and `pmc_kvs_evictions_total` no longer appears.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999efeba3248333960f23978ae43fdf)