### PR TITLE
Graceful shutdown: implement draining with timeout and close-budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,35 @@ python3 ./tcp_server_cluster_test.py -p -b 2048
 
 Tweak batch size (-b) based on your system and network.
 
+### Worker HTTP control-plane endpoints
+
+Each cache worker now exposes lightweight HTTP endpoints on the metrics HTTP server (default `METRICS_PORT`, e.g. `9100`). The cache TCP protocol port (`CACHE_PORT`) remains data-only and does **not** serve HTTP.
+
+- `GET /healthz` → always `200 OK` while the process is alive.
+- `GET /readyz` → `200 OK` only when worker state is `READY`; returns `503 Service Unavailable` during `STARTING`, `DRAINING`, and `STOPPED`.
+- `GET /metrics` and `GET /shard` remain available on the same HTTP server.
+
+Readiness state transitions are monotonic per worker:
+
+`STARTING -> READY -> DRAINING -> STOPPED`
+
+On `SIGTERM`/`SIGINT`, readiness flips to `503` immediately (`DRAINING`) so new traffic can be removed quickly by orchestrators/load-balancers.
+
+### Graceful shutdown and drain
+
+The server implements bounded graceful shutdown for worker processes:
+
+1. Stop accepting new TCP connections.
+2. Keep processing existing active connections while draining.
+3. Exit when all active connections are closed, or force-close remaining connections after a timeout.
+
+New runtime knobs:
+
+- `--drain-timeout-ms` (env: `DRAIN_TIMEOUT_MS`, default: `5000`)
+- `--drain-max-conn-close-per-tick` (env: `DRAIN_MAX_CONN_CLOSE_PER_TICK`, default: `1024`)
+
+These options bound worst-case shutdown time and cap per-tick forced closes to avoid long latency spikes during teardown.
+
 ### Functional tests
 
 #### Testing method

--- a/scripts/run-all-tests.bash
+++ b/scripts/run-all-tests.bash
@@ -7,7 +7,7 @@ pushd ./src > /dev/null
 g++ -std=c++23 -O3 -s -DNDEBUG -pthread -I/usr/include/ -I/usr/local/include/ -L/usr/lib/ hash/*.cpp compressor/gzip_compressor.cpp kvs/*.cpp primegen/primegen.cpp -lz -lgtest -lgtest_main -o ../kvs_test
 g++ -std=c++23 -O3 -s -DNDEBUG -pthread -I/usr/include/ -I/usr/local/include/ compressor/*.cpp -lz -lgtest -lgtest_main -o ../test_gzip
 g++ -std=c++23 -O3 -s -DNDEBUG -pthread -I/usr/include/ -I/usr/local/include/ server/protocol.cpp server/protocol_test.cpp -lgtest -lgtest_main -o ../protocol_test
-g++ -std=c++23 -O3 -s -DNDEBUG -pthread -I/usr/include/ -I/usr/local/include/ metrics/metrics.cpp metrics/metrics_test.cpp -lgtest -lgtest_main -o ../metrics_test
+g++ -std=c++23 -O3 -s -DNDEBUG -pthread -I/usr/include/ -I/usr/local/include/ metrics/metrics.cpp http/http_server.cpp metrics/metrics_test.cpp -lgtest -lgtest_main -o ../metrics_test
 popd > /dev/null
 
 export NUM_ELEMENTS=10000000

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(
   primegen/primegen.cpp
   kvs/kvs.cpp
   metrics/metrics.cpp
+  http/http_server.cpp
   compressor/gzip_compressor.cpp
 )
 

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -1,0 +1,205 @@
+#include "http_server.hpp"
+
+#include <arpa/inet.h>
+#include <chrono>
+#include <cstring>
+#include <netinet/in.h>
+#include <sstream>
+#include <stdexcept>
+#include <string_view>
+#include <sys/socket.h>
+#include <unistd.h>
+
+using namespace http;
+
+namespace {
+constexpr std::string_view METRICS_PATH = "/metrics";
+constexpr std::string_view SHARD_PATH = "/shard";
+constexpr std::string_view HEALTH_PATH = "/healthz";
+constexpr std::string_view READY_PATH = "/readyz";
+constexpr std::string_view HTTP_GET = "GET";
+
+constexpr char HTTP_200_HEALTH[] =
+    "HTTP/1.1 200 OK\r\n"
+    "Content-Type: text/plain\r\n"
+    "Content-Length: 2\r\n"
+    "Connection: close\r\n\r\n"
+    "OK";
+
+constexpr char HTTP_200_READY[] =
+    "HTTP/1.1 200 OK\r\n"
+    "Content-Type: text/plain\r\n"
+    "Content-Length: 6\r\n"
+    "Connection: close\r\n\r\n"
+    "READY\n";
+
+constexpr char HTTP_503_NOT_READY[] =
+    "HTTP/1.1 503 Service Unavailable\r\n"
+    "Content-Type: text/plain\r\n"
+    "Content-Length: 10\r\n"
+    "Connection: close\r\n\r\n"
+    "NOT_READY\n";
+
+constexpr char HTTP_404_NOT_FOUND[] =
+    "HTTP/1.1 404 Not Found\r\n"
+    "Content-Type: text/plain\r\n"
+    "Content-Length: 10\r\n"
+    "Connection: close\r\n\r\n"
+    "NOT_FOUND\n";
+
+std::string_view parseGetPath(std::string_view request) {
+    const auto lineEnd = request.find("\r\n");
+    if (lineEnd == std::string_view::npos) {
+        return {};
+    }
+
+    const auto line = request.substr(0, lineEnd);
+    if (!line.starts_with(HTTP_GET)) {
+        return {};
+    }
+
+    const auto firstSpace = line.find(' ');
+    if (firstSpace == std::string_view::npos) {
+        return {};
+    }
+
+    const auto secondSpace = line.find(' ', firstSpace + 1);
+    if (secondSpace == std::string_view::npos || secondSpace <= firstSpace + 1) {
+        return {};
+    }
+
+    return line.substr(firstSpace + 1, secondSpace - firstSpace - 1);
+}
+} // namespace
+
+HttpServer::HttpServer(HttpServerConfig cfg, metrics::MetricsCollector& collector)
+    : config(std::move(cfg)), collector(collector) {}
+
+HttpServer::~HttpServer() { stop(); }
+
+void HttpServer::start() {
+    if (running.load()) {
+        return;
+    }
+
+    server_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (!server_fd || *server_fd < 0) {
+        throw std::runtime_error("Failed to create metrics socket");
+    }
+
+    int flag = 1;
+    if (setsockopt(*server_fd, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(flag)) == -1) {
+        throw std::runtime_error("Failed to set SO_REUSEADDR for metrics socket");
+    }
+
+    sockaddr_in address{};
+    address.sin_family = AF_INET;
+    address.sin_port = htons(static_cast<uint16_t>(config.listenPort));
+    address.sin_addr.s_addr = inet_addr(config.listenHost.c_str());
+
+    if (bind(*server_fd, reinterpret_cast<sockaddr*>(&address), sizeof(address)) == -1) {
+        throw std::runtime_error("Failed to bind metrics socket");
+    }
+
+    if (listen(*server_fd, 16) == -1) {
+        throw std::runtime_error("Failed to listen on metrics socket");
+    }
+
+    running = true;
+    worker = std::thread([this]() { serveLoop(); });
+}
+
+void HttpServer::stop() {
+    if (!running.exchange(false)) {
+        return;
+    }
+
+    if (server_fd && *server_fd >= 0) {
+        ::shutdown(*server_fd, SHUT_RDWR);
+        ::close(*server_fd);
+    }
+
+    if (worker.joinable()) {
+        worker.join();
+    }
+}
+
+void HttpServer::serveLoop() {
+    while (running.load()) {
+        sockaddr_in client{};
+        socklen_t client_len = sizeof(client);
+        int client_fd = accept(server_fd.value(), reinterpret_cast<sockaddr*>(&client), &client_len);
+        if (client_fd < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            if (!running.load()) {
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            continue;
+        }
+
+        handleClient(client_fd);
+        ::close(client_fd);
+    }
+}
+
+void HttpServer::handleClient(int client_fd) {
+    constexpr std::size_t BUF_SIZE = 2048;
+    char buffer[BUF_SIZE];
+    ssize_t bytes_read = recv(client_fd, buffer, sizeof(buffer) - 1, 0);
+    if (bytes_read <= 0) {
+        return;
+    }
+
+    buffer[bytes_read] = '\0';
+    std::string_view request(buffer, static_cast<std::size_t>(bytes_read));
+    const auto path = parseGetPath(request);
+
+    std::string dynamicBody;
+    std::string_view payload;
+    std::string_view contentType = "text/plain; version=0.0.4";
+
+    if (path == HEALTH_PATH) {
+        payload = std::string_view(HTTP_200_HEALTH, sizeof(HTTP_200_HEALTH) - 1);
+    } else if (path == READY_PATH) {
+        const bool ready = config.readinessProbe ? config.readinessProbe() : true;
+        payload = ready
+            ? std::string_view(HTTP_200_READY, sizeof(HTTP_200_READY) - 1)
+            : std::string_view(HTTP_503_NOT_READY, sizeof(HTTP_503_NOT_READY) - 1);
+    } else if (path == METRICS_PATH) {
+        dynamicBody = collector.renderPrometheus();
+    } else if (path == SHARD_PATH) {
+        dynamicBody = collector.renderShardInfoJson();
+        contentType = "application/json";
+    } else {
+        payload = std::string_view(HTTP_404_NOT_FOUND, sizeof(HTTP_404_NOT_FOUND) - 1);
+    }
+
+    if (payload.empty()) {
+        std::ostringstream response;
+        response << "HTTP/1.1 200 OK\r\n";
+        response << "Content-Type: " << contentType << "\r\n";
+        response << "Content-Length: " << dynamicBody.size() << "\r\n";
+        response << "Connection: close\r\n\r\n";
+        response << dynamicBody;
+        dynamicBody = response.str();
+        payload = dynamicBody;
+    }
+
+    auto remaining = payload.size();
+    const char* data = payload.data();
+
+    while (remaining > 0) {
+        auto sent = send(client_fd, data, remaining, MSG_NOSIGNAL);
+        if (sent <= 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            break;
+        }
+        remaining -= static_cast<std::size_t>(sent);
+        data += sent;
+    }
+}

--- a/src/http/http_server.hpp
+++ b/src/http/http_server.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <atomic>
+#include <functional>
+#include <optional>
+#include <string>
+#include <thread>
+
+#include "../metrics/metrics.hpp"
+
+namespace http {
+
+using ReadinessProbe = std::function<bool()>;
+
+struct HttpServerConfig {
+    std::string listenHost = "0.0.0.0";
+    int listenPort = 9100;
+    ReadinessProbe readinessProbe = {};
+};
+
+class HttpServer {
+  public:
+    HttpServer(HttpServerConfig config, metrics::MetricsCollector& collector);
+    ~HttpServer();
+
+    void start();
+    void stop();
+
+  private:
+    void serveLoop();
+    void handleClient(int client_fd);
+
+    HttpServerConfig config;
+    metrics::MetricsCollector& collector;
+    std::optional<int> server_fd;
+    std::thread worker;
+    std::atomic<bool> running{false};
+};
+
+} // namespace http

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,10 @@
 #include <thread>
 #include <iostream>
+#include <cstdlib>
 #include <signal.h>
+#include <optional>
 #include "metrics/metrics.hpp"
+#include "http/http_server.hpp"
 #include "server/server.hpp"
 #include "env.hpp"
 
@@ -10,6 +13,8 @@ using namespace server;
 int main(int argc, char* argv[]) {
     std::string cliListen;
     std::string metricsListen;
+    std::optional<uint_fast32_t> cliDrainTimeoutMs;
+    std::optional<uint_fast32_t> cliDrainMaxClosePerTick;
     for (int i = 1; i + 1 < argc; ++i) {
         if (std::string_view(argv[i]) == "--listen") {
             cliListen = argv[++i];
@@ -17,6 +22,14 @@ int main(int argc, char* argv[]) {
         }
         if (std::string_view(argv[i]) == "--metrics-listen") {
             metricsListen = argv[++i];
+            continue;
+        }
+        if (std::string_view(argv[i]) == "--drain-timeout-ms") {
+            cliDrainTimeoutMs = std::stoul(argv[++i]);
+            continue;
+        }
+        if (std::string_view(argv[i]) == "--drain-max-conn-close-per-tick") {
+            cliDrainMaxClosePerTick = std::stoul(argv[++i]);
         }
     }
     auto serverPort = cliListen.empty() ? getFromEnv<int>("CACHE_PORT", true) : std::stoi(cliListen);
@@ -25,6 +38,14 @@ int main(int argc, char* argv[]) {
     auto connQueueLimit = getFromEnv<uint_fast32_t>("CONN_QUEUE_LIMIT", false, 1048576);
     auto enableCompression = getFromEnv<bool>("ENABLE_COMPRESSION", false, true);
     auto respInlineCapacity = getFromEnv<std::size_t>("RESP_INLINE_CAPACITY", false, static_cast<std::size_t>(255));
+    auto drainTimeoutMs = getFromEnv<uint_fast32_t>("DRAIN_TIMEOUT_MS", false, 5000);
+    auto drainMaxConnClosePerTick = getFromEnv<uint_fast32_t>("DRAIN_MAX_CONN_CLOSE_PER_TICK", false, 1024);
+    if (cliDrainTimeoutMs.has_value()) {
+        drainTimeoutMs = *cliDrainTimeoutMs;
+    }
+    if (cliDrainMaxClosePerTick.has_value()) {
+        drainMaxConnClosePerTick = *cliDrainMaxClosePerTick;
+    }
 
     auto metricsHost = std::string{getFromEnv<const char*>("METRICS_HOST", false, "0.0.0.0")};
     auto metricsPort = getFromEnv<int>("METRICS_PORT", false, 9100);
@@ -53,14 +74,18 @@ int main(int argc, char* argv[]) {
 
     metricsPort += metricsPortOffset;
 
-    metrics::MetricsConfig metricsConfig{metricsHost, metricsPort, shardLabel, nodeLabel};
+    http::HttpServerConfig httpServerConfig{metricsHost, metricsPort};
     metrics::ShardInfo shardInfo{shardLabel, workerCpu, workerNuma, nicQueueId};
     auto metricsCollector = std::make_shared<metrics::MetricsCollector>(shardLabel, nodeLabel, shardInfo, hotKeySamplerEnabled, hotKeyTopN);
-    metrics::MetricsHttpServer metricsServer{metricsConfig, *metricsCollector};
 
-    ServerSettings serverSettings { serverPort, numShards, sockBufferSize, connQueueLimit, enableCompression, respInlineCapacity };
+    ServerSettings serverSettings { serverPort, numShards, sockBufferSize, connQueueLimit, enableCompression, respInlineCapacity, drainTimeoutMs, drainMaxConnClosePerTick };
 
     CacheServer cacheServer { serverSettings, metricsCollector };
+    httpServerConfig.readinessProbe = [&cacheServer]() noexcept {
+        return cacheServer.workerReadinessState() == WorkerReadinessState::READY;
+    };
+
+    http::HttpServer metricsServer{httpServerConfig, *metricsCollector};
 
     static std::function<void(int)> signalHandler = [&cacheServer](int signal) {
         if (signal == SIGINT || signal == SIGTERM) {

--- a/src/metrics/metrics.cpp
+++ b/src/metrics/metrics.cpp
@@ -1,29 +1,18 @@
 #include "metrics.hpp"
 
-#include <arpa/inet.h>
-#include <chrono>
-#include <cstring>
 #if defined(__GLIBC__)
 #include <features.h>
 #endif
 #include <malloc.h>
-#include <netinet/in.h>
 #include <algorithm>
 #include <array>
 #include <charconv>
 #include <sstream>
-#include <stdexcept>
-#include <string_view>
-#include <sys/socket.h>
-#include <unistd.h>
 
 using namespace metrics;
 
 namespace {
 
-constexpr std::string_view METRICS_PATH = "/metrics";
-constexpr std::string_view SHARD_PATH = "/shard";
-constexpr std::string_view HTTP_GET = "GET";
 constexpr std::array<uint64_t, MetricsSnapshot::BatchHistogramBucketCount> BATCH_BUCKET_BOUNDS{1, 2, 4, 8, 16, 32, 64, 128};
 
 std::string buildLabels(std::string_view shard, std::string_view node, std::string_view extra = {}) {
@@ -60,6 +49,8 @@ uint64_t readArenaBytes() {
     return 0;
 #endif
 }
+
+
 
 } // namespace
 
@@ -296,131 +287,3 @@ std::string MetricsCollector::renderShardInfoJson() const {
     return oss.str();
 }
 
-MetricsHttpServer::MetricsHttpServer(MetricsConfig cfg, MetricsCollector& collector)
-    : config(std::move(cfg)), collector(collector) {}
-
-MetricsHttpServer::~MetricsHttpServer() { stop(); }
-
-void MetricsHttpServer::start() {
-    if (running.load()) {
-        return;
-    }
-
-    server_fd = ::socket(AF_INET, SOCK_STREAM, 0);
-    if (!server_fd || *server_fd < 0) {
-        throw std::runtime_error("Failed to create metrics socket");
-    }
-
-    int flag = 1;
-    if (setsockopt(*server_fd, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(flag)) == -1) {
-        throw std::runtime_error("Failed to set SO_REUSEADDR for metrics socket");
-    }
-
-    sockaddr_in address{};
-    address.sin_family = AF_INET;
-    address.sin_port = htons(static_cast<uint16_t>(config.listenPort));
-    address.sin_addr.s_addr = inet_addr(config.listenHost.c_str());
-
-    if (bind(*server_fd, reinterpret_cast<sockaddr*>(&address), sizeof(address)) == -1) {
-        throw std::runtime_error("Failed to bind metrics socket");
-    }
-
-    if (listen(*server_fd, 16) == -1) {
-        throw std::runtime_error("Failed to listen on metrics socket");
-    }
-
-    running = true;
-    worker = std::thread([this]() { serveLoop(); });
-}
-
-void MetricsHttpServer::stop() {
-    if (!running.exchange(false)) {
-        return;
-    }
-
-    if (server_fd && *server_fd >= 0) {
-        ::shutdown(*server_fd, SHUT_RDWR);
-        ::close(*server_fd);
-    }
-
-    if (worker.joinable()) {
-        worker.join();
-    }
-}
-
-void MetricsHttpServer::serveLoop() {
-    while (running.load()) {
-        sockaddr_in client{};
-        socklen_t client_len = sizeof(client);
-        int client_fd = accept(server_fd.value(), reinterpret_cast<sockaddr*>(&client), &client_len);
-        if (client_fd < 0) {
-            if (errno == EINTR) {
-                continue;
-            }
-            if (!running.load()) {
-                break;
-            }
-            std::this_thread::sleep_for(std::chrono::milliseconds(10));
-            continue;
-        }
-
-        handleClient(client_fd);
-        ::close(client_fd);
-    }
-}
-
-void MetricsHttpServer::handleClient(int client_fd) {
-    constexpr std::size_t BUF_SIZE = 1024;
-    char buffer[BUF_SIZE];
-    ssize_t bytes_read = recv(client_fd, buffer, sizeof(buffer) - 1, 0);
-    if (bytes_read <= 0) {
-        return;
-    }
-
-    buffer[bytes_read] = '\0';
-    std::string_view request(buffer, static_cast<std::size_t>(bytes_read));
-
-    auto endOfLine = request.find('\n');
-    if (endOfLine == std::string_view::npos) {
-        return;
-    }
-
-    auto firstLine = request.substr(0, endOfLine);
-    if (!firstLine.starts_with(HTTP_GET)) {
-        return;
-    }
-
-    std::string body;
-    std::string_view contentType = "text/plain; version=0.0.4";
-    if (firstLine.find(METRICS_PATH) != std::string_view::npos) {
-        body = collector.renderPrometheus();
-    } else if (firstLine.find(SHARD_PATH) != std::string_view::npos) {
-        body = collector.renderShardInfoJson();
-        contentType = "application/json";
-    } else {
-        return;
-    }
-
-    std::ostringstream response;
-    response << "HTTP/1.1 200 OK\r\n";
-    response << "Content-Type: " << contentType << "\r\n";
-    response << "Content-Length: " << body.size() << "\r\n";
-    response << "Connection: close\r\n\r\n";
-    response << body;
-
-    auto payload = response.str();
-    auto remaining = payload.size();
-    const char* data = payload.data();
-
-    while (remaining > 0) {
-        auto sent = send(client_fd, data, remaining, MSG_NOSIGNAL);
-        if (sent <= 0) {
-            if (errno == EINTR) {
-                continue;
-            }
-            break;
-        }
-        remaining -= static_cast<std::size_t>(sent);
-        data += sent;
-    }
-}

--- a/src/metrics/metrics.hpp
+++ b/src/metrics/metrics.hpp
@@ -3,11 +3,9 @@
 #include <atomic>
 #include <cstdint>
 #include <mutex>
-#include <optional>
 #include <span>
 #include <string>
 #include <string_view>
-#include <thread>
 #include <utility>
 #include <vector>
 
@@ -79,13 +77,6 @@ struct ShardInfo {
     std::string nicQueueId = "-1";
 };
 
-struct MetricsConfig {
-    std::string listenHost = "0.0.0.0";
-    int listenPort = 9100;
-    std::string shardLabel = "0";
-    std::string nodeLabel = "local";
-};
-
 class MetricsCollector {
   public:
     MetricsCollector(std::string shardLabel, std::string nodeLabel, ShardInfo shardInfo = {}, bool hotKeySamplerEnabled = false, std::size_t hotKeyTopN = 8);
@@ -121,23 +112,5 @@ class MetricsCollector {
     std::size_t hotKeyTopN = 8;
 };
 
-class MetricsHttpServer {
-  public:
-    MetricsHttpServer(MetricsConfig config, MetricsCollector& collector);
-    ~MetricsHttpServer();
-
-    void start();
-    void stop();
-
-  private:
-    void serveLoop();
-    void handleClient(int client_fd);
-
-    MetricsConfig config;
-    MetricsCollector& collector;
-    std::optional<int> server_fd;
-    std::thread worker;
-    std::atomic<bool> running{false};
-};
 
 } // namespace metrics

--- a/src/metrics/metrics_test.cpp
+++ b/src/metrics/metrics_test.cpp
@@ -1,10 +1,45 @@
 #include <gtest/gtest.h>
 
 #include <string>
+#include <atomic>
+#include <thread>
+#include <chrono>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <unistd.h>
 
 #include "metrics.hpp"
+#include "../http/http_server.hpp"
 
 namespace {
+
+
+std::string sendHttpRequest(int port, std::string_view request) {
+    int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    EXPECT_GE(fd, 0);
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(static_cast<uint16_t>(port));
+    addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+    EXPECT_EQ(::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)), 0);
+
+    auto sent = ::send(fd, request.data(), request.size(), 0);
+    EXPECT_EQ(sent, static_cast<ssize_t>(request.size()));
+
+    std::string response;
+    char buffer[1024];
+    while (true) {
+        auto n = ::recv(fd, buffer, sizeof(buffer), 0);
+        if (n <= 0) {
+            break;
+        }
+        response.append(buffer, static_cast<std::size_t>(n));
+    }
+
+    ::close(fd);
+    return response;
+}
 
 TEST(MetricsCollectorTest, RenderPrometheusIncludesPhase5ObservabilityMetrics) {
     metrics::ShardInfo shardInfo{"2", "4", "1", "4"};
@@ -64,6 +99,32 @@ TEST(MetricsCollectorTest, RenderShardInfoJsonIncludesPlacementMetadata) {
     EXPECT_NE(body.find("\"nic_queue_id\":\"3\""), std::string::npos);
     EXPECT_NE(body.find("\"memory_arena_bytes\":"), std::string::npos);
     EXPECT_NE(body.find("\"in_flight_requests\":2"), std::string::npos);
+}
+
+
+TEST(MetricsHttpServerTest, HealthzAndReadyzReflectProbeState) {
+    std::atomic<bool> ready{false};
+    metrics::ShardInfo shardInfo{"1", "0", "0", "0"};
+    metrics::MetricsCollector collector("1", "node", shardInfo, false, 4);
+
+    http::HttpServerConfig config{"127.0.0.1", 19100};
+    config.readinessProbe = [&ready]() noexcept { return ready.load(std::memory_order_acquire); };
+
+    http::HttpServer server(config, collector);
+    server.start();
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    const auto health = sendHttpRequest(19100, "GET /healthz HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    EXPECT_NE(health.find("HTTP/1.1 200 OK"), std::string::npos);
+
+    const auto notReady = sendHttpRequest(19100, "GET /readyz HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    EXPECT_NE(notReady.find("HTTP/1.1 503 Service Unavailable"), std::string::npos);
+
+    ready.store(true, std::memory_order_release);
+    const auto readyResponse = sendHttpRequest(19100, "GET /readyz HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    EXPECT_NE(readyResponse.find("HTTP/1.1 200 OK"), std::string::npos);
+
+    server.stop();
 }
 
 } // namespace

--- a/src/server/conn_manager.hpp
+++ b/src/server/conn_manager.hpp
@@ -381,6 +381,13 @@ namespace server {
                             break;
                         }
 
+                        if ((lastError == EBADF || lastError == EINVAL) && !isRunning.load(std::memory_order_acquire)) {
+                            // Stop() may close the listen socket while accept loop is winding down.
+                            // Treat this as a graceful shutdown signal rather than a fatal accept error.
+                            lastError = 0;
+                            break;
+                        }
+
                         perror("Failed to accept connection");
                         acceptedCount = -1;
                         break;
@@ -403,4 +410,3 @@ namespace server {
             metrics::MetricsCollector* metrics = nullptr;
     };
 }
-

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -3,52 +3,54 @@
 #include <unordered_map>
 #include <string>
 #include <vector>
+#include <chrono>
 
 using namespace server;
 
 ConnectionData::~ConnectionData() = default;
 
 CacheServer::CacheServer(const ServerSettings settings, std::shared_ptr<metrics::MetricsCollector> metricsCollector)
-    : numShards(settings.numShards), port(settings.port), metrics(std::move(metricsCollector))
+    : numShards(settings.numShards), port(settings.port), metrics(std::move(metricsCollector)), drainTimeout(static_cast<int64_t>(settings.drainTimeoutMs)), drainMaxConnClosePerTick(settings.drainMaxConnClosePerTick)
 {
     setRespInlineCapacity(settings.respInlineCapacity);
 
-    server_fd = socket(AF_INET, SOCK_STREAM, 0);
-    if (server_fd == -1) {
+    const auto listenFd = socket(AF_INET, SOCK_STREAM, 0);
+    server_fd.store(listenFd, std::memory_order_release);
+    if (listenFd == -1) {
         throw std::system_error(errno, std::system_category(), "Socket creation failed");
     }
 
     int flag = 1;
-    if (setsockopt(server_fd, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag)) == -1) {
-        close(server_fd);
+    if (setsockopt(listenFd, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag)) == -1) {
+        close(listenFd);
         throw std::system_error(errno, std::system_category(), "Failed to set TCP_NODELAY for server socket");
     }
-    if (setsockopt(server_fd, IPPROTO_TCP, TCP_DEFER_ACCEPT, &flag, sizeof(flag)) == -1) {
-        close(server_fd);
+    if (setsockopt(listenFd, IPPROTO_TCP, TCP_DEFER_ACCEPT, &flag, sizeof(flag)) == -1) {
+        close(listenFd);
         throw std::system_error(errno, std::system_category(), "Failed to set TCP_DEFER_ACCEPT for server socket");
     }
-    if (setsockopt(server_fd, IPPROTO_TCP, TCP_QUICKACK, &flag, sizeof(flag)) == -1) {
-        close(server_fd);
+    if (setsockopt(listenFd, IPPROTO_TCP, TCP_QUICKACK, &flag, sizeof(flag)) == -1) {
+        close(listenFd);
         throw std::system_error(errno, std::system_category(), "Failed to set TCP_QUICKACK for server socket");
     }
-    if (setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(flag)) == -1) {
-        close(server_fd);
+    if (setsockopt(listenFd, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(flag)) == -1) {
+        close(listenFd);
         throw std::system_error(errno, std::system_category(), "Failed to set SO_REUSEADDR for server socket");
     }
 
     int qlen = 2048;
-    if (setsockopt(server_fd, SOL_TCP, TCP_FASTOPEN, &qlen, sizeof(qlen)) == -1) {
-        close(server_fd);
+    if (setsockopt(listenFd, SOL_TCP, TCP_FASTOPEN, &qlen, sizeof(qlen)) == -1) {
+        close(listenFd);
         throw std::system_error(errno, std::system_category(), "Failed to set TCP_FASTOPEN for server socket");
     }
 
-    if (setSocketBuffers(server_fd, settings.sockBuffer, SOCK_BUF_OPTS::SOCK_BUF_ALL) == -1) {
-        close(server_fd);
+    if (setSocketBuffers(listenFd, settings.sockBuffer, SOCK_BUF_OPTS::SOCK_BUF_ALL) == -1) {
+        close(listenFd);
         throw std::runtime_error("Failed to set socket buffer options for server socket");
     }
 
-    if (setNonBlocking(server_fd) == -1) {
-        close(server_fd);
+    if (setNonBlocking(listenFd) == -1) {
+        close(listenFd);
         throw std::runtime_error("Failed to set O_NONBLOCK for server socket");
     }
 
@@ -57,13 +59,13 @@ CacheServer::CacheServer(const ServerSettings settings, std::shared_ptr<metrics:
     address.sin_addr.s_addr = INADDR_ANY;
     address.sin_port = htons(port);
 
-    if (bind(server_fd, (struct sockaddr*)&address, sizeof(address)) < 0) {
-        close(server_fd);
+    if (bind(listenFd, (struct sockaddr*)&address, sizeof(address)) < 0) {
+        close(listenFd);
         throw std::system_error(errno, std::system_category(), "Bind failed");
     }
 
-    if (listen(server_fd, settings.connQueueLimit) < 0) {
-        close(server_fd);
+    if (listen(listenFd, settings.connQueueLimit) < 0) {
+        close(listenFd);
         throw std::system_error(errno, std::system_category(), "Listen failed");
     }
 
@@ -85,14 +87,11 @@ CacheServer::CacheServer(const ServerSettings settings, std::shared_ptr<metrics:
 }
 
 CacheServer::~CacheServer() {
-    if (server_fd >= 0) {
-        close(server_fd);
-    }
+    disableAccepting();
     if (epoll_fd >= 0) {
         close(epoll_fd);
     }
 }
-
 
 ResponsePacket CacheServer::processRequestSync(const RequestView& request, ConnectionData& connData)
 {
@@ -400,7 +399,7 @@ ResponsePacket CacheServer::processRequestSync(const RequestView& request, Conne
 
 HandleReqTask CacheServer::handleRequests()
 {
-    while (isRunning) {
+    while (isRunning.load(std::memory_order_acquire) || !connManager->connections.empty()) {
 #ifndef NDEBUG
         auto start = std::chrono::high_resolution_clock::now();
 #endif
@@ -512,11 +511,11 @@ HandleReqTask CacheServer::handleRequests()
             for (auto& [fd, responses] : responsesPerConn) {
                 if (responses.empty())
                     continue;
-        
+
                 auto it = connManager->connections.find(fd);
                 if (it == connManager->connections.end())
                     continue;
-        
+
                 ConnectionData& conn = it->second;
 
                 for (const auto& resp : responses) {
@@ -748,19 +747,32 @@ void CacheServer::updateKvsMetrics()
 
 int CacheServer::Start()
 {
-    isRunning = true;
+    isRunning.store(true, std::memory_order_release);
+    setWorkerState(WorkerReadinessState::STARTING);
 
     std::cout << "Server started on port " << port << ", " << numShards << " shards are ready\n";
 
     int resultCode = 0;
 
-    auto acceptTask = connManager->acceptConnections(server_fd, isRunning);
-
+    auto acceptTask = connManager->acceptConnections(server_fd.load(std::memory_order_acquire), isRunning);
     auto hrt = handleRequests();
 
+    if (isRunning.load(std::memory_order_acquire)) {
+        auto expected = static_cast<uint8_t>(WorkerReadinessState::STARTING);
+        workerState.compare_exchange_strong(
+            expected,
+            static_cast<uint8_t>(WorkerReadinessState::READY),
+            std::memory_order_release,
+            std::memory_order_relaxed);
+    }
+
     std::cout << "Cache server is ready to accept connections on port " << port << std::endl;
+
     try {
-        while (isRunning) {
+        bool drainingStarted = false;
+        auto drainStartedAt = std::chrono::steady_clock::now();
+
+        while (true) {
             auto accepted_count = acceptTask.next_value();
             auto events_processed = hrt.next_value();
             if (accepted_count < 0 || events_processed < 0) {
@@ -768,15 +780,57 @@ int CacheServer::Start()
                 break;
             }
 
-            if (accepted_count == 0 && events_processed <= 0) {
-                std::this_thread::sleep_for(PROCESS_REQ_DELAY);
+            if (isRunning.load(std::memory_order_acquire)) {
+                if (accepted_count == 0 && events_processed <= 0) {
+                    std::this_thread::sleep_for(PROCESS_REQ_DELAY);
+                }
+                continue;
             }
-            // TODO: try to recover when events_processed = -1
+
+            if (!drainingStarted) {
+                drainingStarted = true;
+                drainStartedAt = std::chrono::steady_clock::now();
+                disableAccepting();
+                setWorkerState(WorkerReadinessState::DRAINING);
+            }
+
+            if (connManager->connections.empty()) {
+                break;
+            }
+
+            const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - drainStartedAt);
+            if (elapsed >= drainTimeout) {
+                std::vector<int> fdsToClose;
+                const auto maxClose = std::max<uint_fast32_t>(1, drainMaxConnClosePerTick);
+                fdsToClose.reserve(std::min<std::size_t>(connManager->connections.size(), maxClose));
+
+                for (const auto& [fd, _] : connManager->connections) {
+                    if (fdsToClose.size() >= maxClose) {
+                        break;
+                    }
+                    fdsToClose.push_back(fd);
+                }
+
+                for (int fd : fdsToClose) {
+                    connManager->closeConnection(fd, metrics::CloseReason::Server);
+                }
+
+                if (connManager->connections.empty()) {
+                    break;
+                }
+            }
+
+            std::this_thread::sleep_for(PROCESS_REQ_DELAY);
         }
+
+        setWorkerState(WorkerReadinessState::STOPPED);
+        std::cout << "Server stopped.\n";
     }
     catch (const std::exception& ex) {
         std::cerr << "Unrecoverable exception during requests handling: " << ex.what() << '\n';
         Stop();
+        setWorkerState(WorkerReadinessState::STOPPED);
+        resultCode = -1;
     }
 
     return resultCode;
@@ -784,11 +838,30 @@ int CacheServer::Start()
 
 void CacheServer::Stop() noexcept
 {
-    if (!isRunning) {
+    const auto wasRunning = isRunning.exchange(false, std::memory_order_acq_rel);
+    if (!wasRunning) {
         return;
     }
 
     std::cout << "Stopping server…\n";
-    isRunning = false;
-    std::cout << "Server stopped.\n";
+    setWorkerState(WorkerReadinessState::DRAINING);
+    disableAccepting();
+}
+
+void CacheServer::disableAccepting() noexcept
+{
+    const int fd = server_fd.exchange(-1, std::memory_order_acq_rel);
+    if (fd >= 0) {
+        close(fd);
+    }
+}
+
+void CacheServer::setWorkerState(WorkerReadinessState next) noexcept
+{
+    workerState.store(static_cast<uint8_t>(next), std::memory_order_release);
+}
+
+WorkerReadinessState CacheServer::workerReadinessState() const noexcept
+{
+    return static_cast<WorkerReadinessState>(workerState.load(std::memory_order_acquire));
 }

--- a/src/server/server.hpp
+++ b/src/server/server.hpp
@@ -8,6 +8,7 @@
 #include <mutex>
 #include <functional>
 #include <thread>
+#include <chrono>
 #include <vector>
 #include <queue>
 #include <string_view>
@@ -28,6 +29,13 @@
 #include "coroutines.hpp"
 
 namespace server {
+
+    enum class WorkerReadinessState : uint8_t {
+        STARTING = 0,
+        READY = 1,
+        DRAINING = 2,
+        STOPPED = 3,
+    };
 
     using namespace kvs;
 
@@ -90,6 +98,12 @@ namespace server {
 
         /// @brief Inline RESP response capacity before falling back to heap allocations
         std::size_t respInlineCapacity = 255;
+
+        /// @brief Maximum drain duration before force-closing remaining connections
+        uint_fast32_t drainTimeoutMs = 5000;
+
+        /// @brief Max number of connections to force-close per drain tick
+        uint_fast32_t drainMaxConnClosePerTick = 1024;
     };
 
     class CacheServer : NonCopyableOrMovable {
@@ -107,14 +121,17 @@ namespace server {
             std::atomic<uint_fast64_t> numErrors = 0;
             std::atomic<uint_fast64_t> numRequests = 0;
             std::atomic<bool> isRunning = false;
+            std::atomic<uint8_t> workerState{static_cast<uint8_t>(WorkerReadinessState::STARTING)};
             std::shared_ptr<metrics::MetricsCollector> metrics;
             std::size_t bufferedReadBytes = 0;
 
             uint_fast16_t numShards;
             std::vector<ServerShard> serverShards;
             int port;
-            int server_fd;
+            std::atomic<int> server_fd{-1};
             int epoll_fd;
+            std::chrono::milliseconds drainTimeout{5000};
+            uint_fast32_t drainMaxConnClosePerTick = 1024;
             epoll_event epoll_events[MAX_EVENTS];
 
             AsyncReadTask readRequestAsync(int client_fd);
@@ -122,6 +139,8 @@ namespace server {
             HandleReqTask handleRequests();
             void sendResponses(int client_fd, const std::vector<ResponsePacket>& responses);
             void updateKvsMetrics();
+            void setWorkerState(WorkerReadinessState next) noexcept;
+            void disableAccepting() noexcept;
         public:
             CacheServer(const ServerSettings settings = ServerSettings{}, std::shared_ptr<metrics::MetricsCollector> metrics = nullptr);
             ~CacheServer();
@@ -129,6 +148,8 @@ namespace server {
             /// @brief Starts processing incoming requests
             /// @return operation result, 0 - success, other values - failure
             int Start();
+
+            WorkerReadinessState workerReadinessState() const noexcept;
 
             /// @brief Gracefully stops server, restart is not (yet) supported
             void Stop() noexcept;


### PR DESCRIPTION
### Motivation

- Implement D2: ensure SIGTERM/SIGINT trigger a graceful shutdown that stops accepting new connections and drains existing ones, with a configurable force-close timeout and per-tick close budget. 
- Make readiness reflect shutdown quickly (readiness probe -> 503) and avoid accepting new clients during drain. 
- Provide CLI/env knobs to tune drain behavior for production deployments (default 5000ms timeout, 1024 close-per-tick). 

### Description

- Added drain configuration to `ServerSettings`: `drainTimeoutMs` and `drainMaxConnClosePerTick`, and threaded them into `CacheServer` runtime fields. (`src/server/server.hpp`, `src/main.cpp`).
- Implemented idempotent accept shutdown via atomic `server_fd` and `disableAccepting()` that exchanges and closes the listen fd; called from `Stop()` and destructor to stop new accepts safely. (`src/server/server.cpp`, `src/server/server.hpp`).
- Updated main server loop in `Start()` to continue processing existing connections after `Stop()` is requested, transition to `DRAINING`, and either finish when there are no active connections or, after `drainTimeout`, force-close up to `drainMaxConnClosePerTick` connections per tick until empty; finalizes to `STOPPED` and exits. This limits per-tick work to avoid long pauses. (`src/server/server.cpp`).
- Wire CLI and environment overrides: `--drain-timeout-ms` and `--drain-max-conn-close-per-tick` with env fallbacks `DRAIN_TIMEOUT_MS` / `DRAIN_MAX_CONN_CLOSE_PER_TICK`, and preserved readiness probe integration via the HTTP metrics/readiness server. (`src/main.cpp`, new `src/http/*` files). 

### Testing

- Built release binary: `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j` (succeeded). 
- Ran unit test suite: `bash scripts/run-all-tests.bash` (all test binaries passed). 
- Performed a functional RPS harness and shutdown validation using the provided TCP test harness (`tests/tcp_server_test.py`) while starting the server with `--drain-timeout-ms 2000 --drain-max-conn-close-per-tick 128`; observed no new accepts after shutdown was signaled and the server exited within the expected window (drain + small overhead). All automated tests reported success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b67b6d19c833389c056efc89ec067)