### PR TITLE
Add startup self-checks and fail-fast worker initialization

### DIFF
--- a/scripts/run-all-tests.bash
+++ b/scripts/run-all-tests.bash
@@ -8,6 +8,7 @@ g++ -std=c++23 -O3 -s -DNDEBUG -pthread -I/usr/include/ -I/usr/local/include/ -L
 g++ -std=c++23 -O3 -s -DNDEBUG -pthread -I/usr/include/ -I/usr/local/include/ compressor/*.cpp -lz -lgtest -lgtest_main -o ../test_gzip
 g++ -std=c++23 -O3 -s -DNDEBUG -pthread -I/usr/include/ -I/usr/local/include/ server/protocol.cpp server/protocol_test.cpp -lgtest -lgtest_main -o ../protocol_test
 g++ -std=c++23 -O3 -s -DNDEBUG -pthread -I/usr/include/ -I/usr/local/include/ metrics/metrics.cpp http/http_server.cpp metrics/metrics_test.cpp -lgtest -lgtest_main -o ../metrics_test
+g++ -std=c++23 -O3 -s -DNDEBUG -pthread -I/usr/include/ -I/usr/local/include/ server/server.cpp server/shard.cpp server/protocol.cpp server/sockutils.cpp server/coroutines.cpp utils/time.cpp hash/MurmurHash3.cpp hash/hash.cpp kvs/kvs.cpp primegen/primegen.cpp compressor/gzip_compressor.cpp metrics/metrics.cpp server/server_startup_test.cpp -lz -lgtest -lgtest_main -o ../server_startup_test
 popd > /dev/null
 
 export NUM_ELEMENTS=10000000
@@ -26,5 +27,9 @@ echo 'Running gzip tests...'
 echo 'Running metrics tests...'
 
 ./metrics_test
+
+echo 'Running server startup tests...'
+
+./server_startup_test
 
 echo 'All tests completed successfully.'

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,8 @@
 #include <cstdlib>
 #include <signal.h>
 #include <optional>
+#include <memory>
+#include <exception>
 #include "metrics/metrics.hpp"
 #include "http/http_server.hpp"
 #include "server/server.hpp"
@@ -11,6 +13,7 @@
 using namespace server;
 
 int main(int argc, char* argv[]) {
+    try {
     std::string cliListen;
     std::string metricsListen;
     std::optional<uint_fast32_t> cliDrainTimeoutMs;
@@ -47,6 +50,7 @@ int main(int argc, char* argv[]) {
         drainMaxConnClosePerTick = *cliDrainMaxClosePerTick;
     }
 
+    auto metricsEnabled = getFromEnv<bool>("METRICS_ENABLED", false, true);
     auto metricsHost = std::string{getFromEnv<const char*>("METRICS_HOST", false, "0.0.0.0")};
     auto metricsPort = getFromEnv<int>("METRICS_PORT", false, 9100);
     auto metricsPortOffset = getFromEnv<int>("METRICS_PORT_OFFSET", false, 0);
@@ -85,7 +89,14 @@ int main(int argc, char* argv[]) {
         return cacheServer.workerReadinessState() == WorkerReadinessState::READY;
     };
 
-    http::HttpServer metricsServer{httpServerConfig, *metricsCollector};
+    std::string startupCheckError;
+    if (!cacheServer.runStartupSelfChecks(&startupCheckError)) {
+        std::cerr << startupCheckError << std::endl;
+        return EXIT_FAILURE;
+    }
+    std::cout << "startup self-check: data port bind success and shard arenas allocated" << std::endl;
+
+    std::unique_ptr<http::HttpServer> metricsServer;
 
     static std::function<void(int)> signalHandler = [&cacheServer](int signal) {
         if (signal == SIGINT || signal == SIGTERM) {
@@ -102,6 +113,15 @@ int main(int argc, char* argv[]) {
     signal(SIGINT, signalDispatcher);
     signal(SIGTERM, signalDispatcher);
 
-    metricsServer.start();
+    if (metricsEnabled) {
+        metricsServer = std::make_unique<http::HttpServer>(httpServerConfig, *metricsCollector);
+        metricsServer->start();
+        std::cout << "startup self-check: metrics port bind success" << std::endl;
+    }
+
     return cacheServer.Start();
+    } catch (const std::exception& ex) {
+        std::cerr << "fatal startup error: " << ex.what() << std::endl;
+        return EXIT_FAILURE;
+    }
 }

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -836,6 +836,62 @@ int CacheServer::Start()
     return resultCode;
 }
 
+bool CacheServer::runStartupSelfChecks(std::string* error) const noexcept
+{
+    if (server_fd.load(std::memory_order_acquire) < 0) {
+        if (error) {
+            *error = "startup self-check failed: data port is not bound";
+        }
+        return false;
+    }
+
+    if (epoll_fd < 0) {
+        if (error) {
+            *error = "startup self-check failed: epoll is not initialized";
+        }
+        return false;
+    }
+
+    if (!connManager) {
+        if (error) {
+            *error = "startup self-check failed: connection manager is not initialized";
+        }
+        return false;
+    }
+
+    if (numShards == 0) {
+        if (error) {
+            *error = "startup self-check failed: number of shards must be greater than zero";
+        }
+        return false;
+    }
+
+    if (serverShards.size() != numShards) {
+        if (error) {
+            *error = "startup self-check failed: shard count mismatch";
+        }
+        return false;
+    }
+
+    for (std::size_t i = 0; i < serverShards.size(); ++i) {
+        const auto& shard = serverShards[i];
+        if (!shard.keyValueStore) {
+            if (error) {
+                *error = "startup self-check failed: shard KVS is missing";
+            }
+            return false;
+        }
+        if (shard.keyValueStore->getPoolCapacity() == 0) {
+            if (error) {
+                *error = "startup self-check failed: shard memory arena is not allocated";
+            }
+            return false;
+        }
+    }
+
+    return true;
+}
+
 void CacheServer::Stop() noexcept
 {
     const auto wasRunning = isRunning.exchange(false, std::memory_order_acq_rel);

--- a/src/server/server.hpp
+++ b/src/server/server.hpp
@@ -11,6 +11,7 @@
 #include <chrono>
 #include <vector>
 #include <queue>
+#include <string>
 #include <string_view>
 #include <fcntl.h>
 #include <unistd.h>
@@ -148,6 +149,8 @@ namespace server {
             /// @brief Starts processing incoming requests
             /// @return operation result, 0 - success, other values - failure
             int Start();
+
+            bool runStartupSelfChecks(std::string* error = nullptr) const noexcept;
 
             WorkerReadinessState workerReadinessState() const noexcept;
 

--- a/src/server/server_startup_test.cpp
+++ b/src/server/server_startup_test.cpp
@@ -1,0 +1,45 @@
+#include <gtest/gtest.h>
+
+#include "server.hpp"
+
+namespace {
+
+TEST(CacheServerStartupChecksTest, PassesForValidServerInitialization) {
+    server::ServerSettings settings{};
+    settings.port = 0;
+    settings.numShards = 2;
+
+    auto metrics = std::make_shared<metrics::MetricsCollector>(
+        "0",
+        "test-node",
+        metrics::ShardInfo{"0", "0", "0", "0"},
+        false,
+        8);
+
+    server::CacheServer cacheServer{settings, metrics};
+
+    std::string error;
+    EXPECT_TRUE(cacheServer.runStartupSelfChecks(&error));
+    EXPECT_TRUE(error.empty());
+}
+
+TEST(CacheServerStartupChecksTest, FailsWhenShardCountIsZero) {
+    server::ServerSettings settings{};
+    settings.port = 0;
+    settings.numShards = 0;
+
+    auto metrics = std::make_shared<metrics::MetricsCollector>(
+        "0",
+        "test-node",
+        metrics::ShardInfo{"0", "0", "0", "0"},
+        false,
+        8);
+
+    server::CacheServer cacheServer{settings, metrics};
+
+    std::string error;
+    EXPECT_FALSE(cacheServer.runStartupSelfChecks(&error));
+    EXPECT_EQ(error, "startup self-check failed: number of shards must be greater than zero");
+}
+
+} // namespace


### PR DESCRIPTION
### Motivation

- Harden worker startup so a single worker failure cannot silently cascade through the cluster by failing fast on critical init errors. 
- Ensure required runtime invariants are validated early (data port bind, epoll/conn-manager, shard arenas) to enforce the crash-isolation contract (D3).

### Description

- Added `CacheServer::runStartupSelfChecks(std::string* error)` that validates data socket presence, `epoll` initialization, `ConnManager` initialization, non-zero `numShards`, and per-shard KVS arena allocation via `getPoolCapacity()`.
- Wrapped `main` startup flow in a `try/catch` and call to `runStartupSelfChecks()` so critical initialization errors return non-zero exit codes instead of continuing to run; introduced `METRICS_ENABLED` and conditional metrics server startup to allow metrics port binding to be optional at boot.
- Added unit tests in `src/server/server_startup_test.cpp` covering a successful initialization case and a zero-shard fail-fast case. 
- Extended `scripts/run-all-tests.bash` to compile and run the new startup test binary as part of automated verification.

### Testing

- Ran the full test script with `bash scripts/run-all-tests.bash` and all test suites passed, including the new `server_startup_test` (automated tests completed successfully).
- Verified build with `cmake -S . -B build && cmake --build build -j4`, which completed successfully and produced the `poor-man-s-cache` binary.
- Performed functional verification by launching the built server and running the Python functional suite (`tests/tcp_server_test.py`) against it, which completed with no failures and expected RPS reports.
- Ran `cd launcher && go test ./...` and the launcher tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e10f6299083338370a62c7dcace54)